### PR TITLE
feat: add `whoami` to print agent DID

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,7 +3,7 @@
 import sade from 'sade'
 import open from 'open'
 import { getPkg, unwarnify } from './lib.js'
-import { createSpace, registerSpace, createDelegation, upload, list } from './index.js'
+import { createSpace, registerSpace, createDelegation, upload, list, whoami } from './index.js'
 
 unwarnify()
 
@@ -30,6 +30,10 @@ cli.command('ls')
   .option('--json', 'Format as newline delimted JSON')
   .option('--shards', 'Pretty print with shards in output')
   .action(list)
+
+cli.command('whoami')
+  .describe('Print information about the current agent.')
+  .action(whoami)
 
 cli.command('space')
   .describe('Create and mangage w3 spaces')

--- a/index.js
+++ b/index.js
@@ -129,3 +129,9 @@ export async function createDelegation (audienceDID, opts) {
   }
   await writer.close()
 }
+
+export async function whoami () {
+  const client = await create()
+  const who = client.agent()
+  console.log(who.did())
+}

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -12,6 +12,11 @@ test('w3 --version', (t) => {
   t.regex(stdout, /w3, \d.\d.\d/)
 })
 
+test('w3 whoami', (t) => {
+  const { stdout } = execaSync('./bin.js', ['whoami'])
+  t.regex(stdout, /^did:key:/)
+})
+
 test('w3 space create', (t) => {
   const { stdout } = execaSync('./bin.js', ['space', 'create'])
   t.regex(stdout, /^did:key:/)


### PR DESCRIPTION
a minimal implementation. The assumption is this command will get more useful once we have [w3accounts](https://github.com/web3-storage/specs/blob/main/w3-account.md)

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>