### PR TITLE
fix: missing file name when only single path passed to filesFromPaths

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -140,7 +140,7 @@ export async function filesFromPaths (paths, options) {
       files.push(file)
       const nameParts = file.name.split('/')
       if (commonParts == null) {
-        commonParts = nameParts
+        commonParts = nameParts.slice(0, -1)
         continue
       }
       for (let i = 0; i < commonParts.length; i++) {

--- a/lib.js
+++ b/lib.js
@@ -138,7 +138,7 @@ export async function filesFromPaths (paths, options) {
   for (const p of paths) {
     for await (const file of filesFromPath(p, options)) {
       files.push(file)
-      const nameParts = file.name.split('/')
+      const nameParts = file.name.split(path.sep)
       if (commonParts == null) {
         commonParts = nameParts.slice(0, -1)
         continue

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -20,3 +20,9 @@ test('filesFromPaths removes common path prefix', async (t) => {
     t.false(file.name.startsWith('test/'))
   }
 })
+
+test('filesFromPaths single file has name', async (t) => {
+  const files = await filesFromPaths(['test/fixtures/empty.car'])
+  t.is(files.length, 1)
+  t.is(files[0].name, 'empty.car')
+})


### PR DESCRIPTION
The common path for the first file was set to the entire `path`, not `dirname(path)`. For multiple files the common path ends up as `dirname(path)` but when there's only 1 it stays as `path`, so we end up stripping out the entire path 🤦‍♂️.