### PR TITLE
fix: remove warnings using shebang

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,8 +1,8 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --no-warnings
 
 import sade from 'sade'
 import open from 'open'
-import { getPkg, unwarnify } from './lib.js'
+import { getPkg } from './lib.js'
 import {
   createSpace,
   registerSpace,
@@ -21,8 +21,6 @@ import {
   storeAdd,
   uploadAdd
 } from './can.js'
-
-unwarnify()
 
 const cli = sade('w3')
 

--- a/lib.js
+++ b/lib.js
@@ -37,25 +37,6 @@ export function filesize (bytes) {
 }
 
 /**
- * Patch process.emit to skip experimental api warnings for fetch. ONLY FORWARDS!
- * source: https://stackoverflow.com/a/73525885/6490163
- */
-export function unwarnify () {
-  const originalEmit = process.emit
-  process.emit = function (name, data) {
-    if (
-      name === 'warning' &&
-      typeof data === 'object' &&
-      data.name === 'ExperimentalWarning' &&
-      data.message.includes('Fetch API')
-    ) {
-      return false
-    }
-    return originalEmit.apply(process, arguments)
-  }
-}
-
-/**
  * Get a new API client configured from env vars.
  */
 export function getClient () {


### PR DESCRIPTION
supress node warnings as we are a CLI. No need to scare the users about the experimental status of things.

patching emit didn't work. I thought it did, but it seems not. This works, but i have no idea what windows will do with it.

_before_
```sh
❯ ./bin.js up ~/Pictures/3.jpg
  1 file (0.2MB)
⠋ Storing(node:39756) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  bagbaieraytfm7hxlzzr4vmckazjiiwraozzrcj2bwqsipi5mtzgyxfc523lq
```

_after_
```sh
❯ ./bin.js up ~/Pictures/3.jpg
  1 file (0.2MB)
  bagbaieraytfm7hxlzzr4vmckazjiiwraozzrcj2bwqsipi5mtzgyxfc523lq
```

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>