### PR TITLE
fix: dont error on systems that cant pass flags to env in shebang

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env node
 
 import sade from 'sade'
 import open from 'open'

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "(Apache-2.0 AND MIT)",
   "description": "💾 w3 command line interface",
   "bin": {
-    "w3": "bin.js",
-    "w3up": "bin.js"
+    "w3": "shim.js",
+    "w3up": "shim.js"
   },
   "scripts": {
     "lint": "standard",

--- a/shim.js
+++ b/shim.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+// Suppress experimental warnings from node
+// see: https://github.com/nodejs/node/issues/30810
+
+const defaultEmit = process.emit
+process.emit = function (...args) {
+  if (args[1].name === 'ExperimentalWarning') {
+    return undefined
+  }
+
+  return defaultEmit.call(this, ...args)
+}
+
+await import('./bin.js')


### PR DESCRIPTION
Using flags in a shebang fails on some systems see https://github.com/web3-storage/w3cli/issues/37

Remove the flag from the shebang. Go back to shimming process.emit, but this time it works. 

**shimmed flavour**
```bash
~/Code/web3-storage/w3cli on main •
❯ ./shim.js up ~/Pictures/behemoth-black-hole-found-in-an-unlikely-place_26209716511_o\~orig.jpeg
  1 file (8.4MB)
  bagbaieravvyvhoig75tgrvel6cxoqchnsftz4lltduxjckqugmaidmyua2rq
⁂ Stored 1 file
⁂ https://w3s.link/ipfs/bafybeidpouz7j6to2p7ps4j262ii32ov5wnp3rj4slavvsm4dfvonvrc6q
```

Sounds like ESM module load order was the problem last time in #9 
> Since imports in ESM run [async](https://stackoverflow.com/questions/35551366/what-is-the-defined-execution-order-of-es6-imports), we have to make sure that the import runs before all other imports. This is needed when you cannot pass suppress-experimental-warnings via a a CLI argument. Note that at the time of writing this documentation, the import order seems to be non-deterministic (also for sync import).
– https://github.com/dword-design/suppress-experimental-warnings#via-esm

see: https://github.com/nodejs/node/issues/30810

fixes: #37 

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>