### PR TITLE
Add options for passing client's credentials with env variables

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -6,9 +6,11 @@ import { connect } from '@ucanto/client'
 import * as CAR from '@ucanto/transport/car'
 import * as CBOR from '@ucanto/transport/cbor'
 import * as HTTP from '@ucanto/transport/http'
+import { derive } from "@ucanto/principal/ed25519";
 import { parse } from '@ipld/dag-ucan/did'
-import { create } from '@web3-storage/w3up-client'
+import { Client, create } from '@web3-storage/w3up-client'
 import { StoreConf } from '@web3-storage/access/stores/store-conf'
+import { AgentData } from "@web3-storage/access";
 import { CarReader } from '@ipld/car'
 
 /**
@@ -42,8 +44,14 @@ export function filesize (bytes) {
  * Get a new API client configured from env vars.
  */
 export function getClient () {
+  if (process.env.W3_PRINCIPAL_KEY && process.env.W3_DELEGATION_PROOF) {
+    // use credentials from env variables
+    return createFromStatic(process.env.W3_PRINCIPAL_KEY, process.env.W3_DELEGATION_PROOF)
+  }
+  
+  // use stored credentials
   const store = new StoreConf({ profile: process.env.W3_STORE_NAME ?? 'w3cli' })
-
+  
   let serviceConf
   if (
     process.env.W3_ACCESS_SERVICE_DID &&
@@ -192,4 +200,28 @@ async function * filesFromDir (dir, filter) {
       yield * filesFromDir(path.join(dir, entry.name), filter)
     }
   }
+}
+
+async function createFromStatic(principalKey, delegationProof) {
+  // create a client with the UCAN private key
+  const principal = await derive(
+    Buffer.from(principalKey, "base64")
+  );
+  const data = await AgentData.create({ principal });
+  const client = new Client(data);
+
+  // create a space with the delegation proof
+  const blocks = [];
+  const reader = await CarReader.fromBytes(
+    Buffer.from(delegationProof, "base64")
+  );
+  for await (const block of reader.blocks()) {
+    blocks.push(block);
+  }
+  const proof = importDAG(blocks);
+
+  const space = await client.addSpace(proof);
+  await client.setCurrentSpace(space.did());
+
+  return client;
 }


### PR DESCRIPTION
Allow interaction with web3.storage service using credentials (principal key and delegation proof) passed as base64-encoded env variables.

**Rationale**

Taking [AWS CLI as an example](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html), you can either use `aws configure` and store the credentials in your local config file or use `aws` with "inline" credentials.

```
export AWS_ACCESS_KEY_ID=<access-key-id>
export AWS_SECRET_ACCESS_KEY=<secret-access-key>
```

This PR will help the `w3` in the ad-hoc usage and for the multi-tenant environments.