### PR TITLE
fix: pass cursor to list in `w3 ls`

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ export async function list (opts) {
   let count = 0
   let res
   do {
-    res = await client.capability.upload.list()
+    res = await client.capability.upload.list({ cursor: res?.cursor })
     count += res.results.length
     if (res.results.length) {
       if (opts.json) {


### PR DESCRIPTION
fixes #48

I added a test for this, but the issue doesn't happen in our current mock impl. I can spend some more time to make the mock implementation support `--size` and `--cursor` but it's not clear to me that's the right move yet - feels a little like adding extra code just to make a  test fail.