### PR TITLE
refactor: use new `files-from-path` module

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ import { Readable } from 'stream'
 import { CID } from 'multiformats/cid'
 import * as DID from '@ipld/dag-ucan/did'
 import { CarWriter } from '@ipld/car'
-import { getClient, checkPathsExist, filesize, readProof, filesFromPaths, uploadListResponseToString } from './lib.js'
+import { filesFromPaths } from 'files-from-path'
+import { getClient, checkPathsExist, filesize, readProof, uploadListResponseToString } from './lib.js'
 
 /**
  * @param {string} firstPath

--- a/lib.js
+++ b/lib.js
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import tree from 'pretty-tree'
-import { Readable } from 'stream'
 import { importDAG } from '@ucanto/core/delegation'
 import { connect } from '@ucanto/client'
 import * as CAR from '@ucanto/transport/car'
@@ -109,92 +108,6 @@ export async function readProof (path) {
   } catch (err) {
     console.error(`Error: failed to import proof: ${err.message}`)
     process.exit(1)
-  }
-}
-
-/**
- * @param {string[]} paths
- * @param {object} [options]
- * @param {boolean} [options.hidden]
- * @returns {Promise<FileLike[]>}
- */
-export async function filesFromPaths (paths, options) {
-  /** @type {string[]|undefined} */
-  let commonParts
-  const files = []
-  for (const p of paths) {
-    for await (const file of filesFromPath(p, options)) {
-      files.push(file)
-      const nameParts = file.name.split(path.sep)
-      if (commonParts == null) {
-        commonParts = nameParts.slice(0, -1)
-        continue
-      }
-      for (let i = 0; i < commonParts.length; i++) {
-        if (commonParts[i] !== nameParts[i]) {
-          commonParts = commonParts.slice(0, i)
-          break
-        }
-      }
-    }
-  }
-  const commonPath = `${(commonParts ?? []).join('/')}/`
-  return files.map(f => ({ ...f, name: f.name.slice(commonPath.length) }))
-}
-
-/**
- * @param {string} filepath
- * @param {object} [options]
- * @param {boolean} [options.hidden]
- * @returns {AsyncIterableIterator<FileLike>}
- */
-async function * filesFromPath (filepath, options = {}) {
-  filepath = path.resolve(filepath)
-  const hidden = options.hidden ?? false
-
-  /** @param {string} filepath */
-  const filter = filepath => {
-    if (!hidden && path.basename(filepath).startsWith('.')) return false
-    return true
-  }
-
-  const name = filepath
-  const stat = await fs.promises.stat(filepath)
-
-  if (!filter(name)) {
-    return
-  }
-
-  if (stat.isFile()) {
-    const stream = () => Readable.toWeb(fs.createReadStream(filepath))
-    // @ts-expect-error node web stream not type compatible with web stream
-    yield { name, stream, size: stat.size }
-  } else if (stat.isDirectory()) {
-    yield * filesFromDir(filepath, filter)
-  }
-}
-
-/**
- * @param {string} dir
- * @param {(name: string) => boolean} filter
- * @returns {AsyncIterableIterator<FileLike>}
- */
-async function * filesFromDir (dir, filter) {
-  const entries = await fs.promises.readdir(path.join(dir), { withFileTypes: true })
-  for (const entry of entries) {
-    if (!filter(entry.name)) {
-      continue
-    }
-
-    if (entry.isFile()) {
-      const name = path.join(dir, entry.name)
-      const { size } = await fs.promises.stat(name)
-      const stream = () => Readable.toWeb(fs.createReadStream(name))
-      // @ts-expect-error node web stream not type compatible with web stream
-      yield { name, stream, size }
-    } else if (entry.isDirectory()) {
-      yield * filesFromDir(path.join(dir, entry.name), filter)
-    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ucanto/transport": "^4.0.3",
         "@web3-storage/access": "^9.1.1",
         "@web3-storage/w3up-client": "^4.2.0",
+        "files-from-path": "^1.0.0",
         "open": "^8.4.0",
         "ora": "^6.1.2",
         "pretty-tree": "^1.0.0",
@@ -2456,6 +2457,17 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/files-from-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.0.tgz",
+      "integrity": "sha512-EobUbrzh1fPOZpQvDdTikGpCs+ZDcTNyBOnFuHvW2BQXEkMSPbEPQ0eVTQrz0oHlBcPS9Lnw+uPzACfft1sDYg==",
+      "dependencies": {
+        "graceful-fs": "^4.2.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2748,8 +2760,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -7788,6 +7799,14 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "files-from-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.0.tgz",
+      "integrity": "sha512-EobUbrzh1fPOZpQvDdTikGpCs+ZDcTNyBOnFuHvW2BQXEkMSPbEPQ0eVTQrz0oHlBcPS9Lnw+uPzACfft1sDYg==",
+      "requires": {
+        "graceful-fs": "^4.2.10"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7990,8 +8009,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@ucanto/transport": "^4.0.3",
     "@web3-storage/access": "^9.1.1",
     "@web3-storage/w3up-client": "^4.2.0",
+    "files-from-path": "^1.0.0",
     "open": "^8.4.0",
     "ora": "^6.1.2",
     "pretty-tree": "^1.0.0",

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -1,37 +1,10 @@
 import test from 'ava'
 import * as CID from 'multiformats/cid'
 import {
-  filesFromPaths,
   filesize,
   uploadListResponseToString,
   storeListResponseToString
 } from '../lib.js'
-
-test('filesFromPaths', async (t) => {
-  const files = await filesFromPaths(['node_modules'])
-  t.log(`${files.length} files in node_modules`)
-  t.true(files.length > 1)
-})
-
-test('filesFromPaths includes file size', async (t) => {
-  const files = await filesFromPaths(['test/fixtures/empty.car'])
-  t.is(files.length, 1)
-  t.is(files[0].size, 18)
-})
-
-test('filesFromPaths removes common path prefix', async (t) => {
-  const files = await filesFromPaths(['test/fixtures', './test/helpers'])
-  t.true(files.length > 1)
-  for (const file of files) {
-    t.false(file.name.startsWith('test/'))
-  }
-})
-
-test('filesFromPaths single file has name', async (t) => {
-  const files = await filesFromPaths(['test/fixtures/empty.car'])
-  t.is(files.length, 1)
-  t.is(files[0].name, 'empty.car')
-})
 
 test('filesize', t => {
   [


### PR DESCRIPTION
The `files-from-path` module has been updated to do what the code here was doing.

TLDR; web streams and automatic common prefix removal.

More info: https://github.com/web3-storage/files-from-path/pull/23