### PR TITLE
fix: add output command to w3 space

### DIFF
--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -341,12 +341,6 @@ test('w3 delegation ls', async t => {
   t.is(delegationData.capabilities[0].can, '*')
 })
 
-test('w3 space', async t => {
-  const aliceEnv = t.context.env.alice
-
-  await t.notThrowsAsync(() => execa('./bin.js', ['space'], { env: aliceEnv }))
-})
-
 test('w3 space add', async t => {
   const aliceEnv = t.context.env.alice
   const bobEnv = t.context.env.bob


### PR DESCRIPTION
We had no output for `w3 space` command resulting in ugly user errors as mentioned in #44.

This PR addresses it. There is nothing clear we want to output. Therefore, looked like a good option to list user agent spaces and instruct on how to do other space commands. As alternatives, we can:
- output docs for the space commands available right away
- simply drop this top level space command. We do not have one for other ones like `delegation` , `proof`, ...

Thoughts?

Closes #44 