### PR TITLE
feat!: move `space register` email parameter to an `--email` option and add `--provider` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ Install the CLI from npm :
 npm install -g @web3-storage/w3cli
 ```
 
+Authorize this agent to act on behalf of the account associated with your email address:
+
+```console
+w3 authorize alice@example.com
+```
+
 Create a new space for storing your data and register it:
 
 ```console
 w3 space create Documents # pick a good name!
-w3 space register alice@example.com
+w3 space register
 ```
 
 Upload a file or directory:
@@ -123,9 +129,12 @@ Create a new w3 space with an optional name.
 
 List spaces known to the agent.
 
-### `w3 space register <email>`
+### `w3 space register [email]`
 
-Claim the space by associating it with your email address.
+Register the space by adding a storage provider and delegating all of its 
+capabilities to the currently authorized account. If you are authorized against
+more than one account you'll need to pass email to specify which account to
+register the space with.
 
 ### `w3 space use <did>`
 

--- a/README.md
+++ b/README.md
@@ -129,13 +129,14 @@ Create a new w3 space with an optional name.
 
 List spaces known to the agent.
 
-### `w3 space register [email]`
+### `w3 space register`
 
 Register the space by adding a storage provider and delegating all of its 
 capabilities to the currently authorized account. If you are authorized against
-more than one account you'll need to pass email to specify which account to
+more than one account you'll need to pass the `--email` option to specify which account to
 register the space with.
 
+* `--email` The email address of the account to associate this space with.
 * `--provider` The storage provider to associate with this space.
 
 ### `w3 space use <did>`

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ capabilities to the currently authorized account. If you are authorized against
 more than one account you'll need to pass email to specify which account to
 register the space with.
 
+* `--provider` The storage provider to associate with this space.
+
 ### `w3 space use <did>`
 
 Set the current space in use by the agent.

--- a/bin.js
+++ b/bin.js
@@ -74,7 +74,7 @@ cli.command('space create [name]')
   .describe('Create a new w3 space')
   .action(createSpace)
 
-cli.command('space register <email>')
+cli.command('space register [email]')
   .describe('Claim the space by associating it with your email address')
   .action(registerSpace)
 

--- a/bin.js
+++ b/bin.js
@@ -76,6 +76,7 @@ cli.command('space create [name]')
 
 cli.command('space register [email]')
   .describe('Claim the space by associating it with your email address')
+  .option('-p, --provider', 'The storage provider to associate with this space.')
   .action(registerSpace)
 
 cli.command('space add <proof>')

--- a/bin.js
+++ b/bin.js
@@ -74,8 +74,9 @@ cli.command('space create [name]')
   .describe('Create a new w3 space')
   .action(createSpace)
 
-cli.command('space register [email]')
+cli.command('space register')
   .describe('Claim the space by associating it with your email address')
+  .option('-e, --email', 'The email address of the account to associate this space with.')
   .option('-p, --provider', 'The storage provider to associate with this space.')
   .action(registerSpace)
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import * as DID from '@ipld/dag-ucan/did'
 import { CarWriter } from '@ipld/car'
 import { filesFromPaths } from 'files-from-path'
 import { getClient, checkPathsExist, filesize, readProof, uploadListResponseToString } from './lib.js'
+import * as ucanto from '@ucanto/core'
 
 export async function accessClaim () {
   const client = await getClient()
@@ -158,11 +159,45 @@ export async function createSpace (name) {
   console.log(space.did())
 }
 
+function findAccountsThatCanProviderAdd (client) {
+  const accounts = []
+  const proofs = client.proofs()
+  for (const proof of proofs) {
+    const allows = ucanto.Delegation.allows(proof)
+    for (const resourceDID of Object.keys(allows)) {
+      if (resourceDID.startsWith('did:mailto:') && allows[resourceDID]['provider/add']) {
+        accounts.push(resourceDID)
+      }
+    }
+  }
+  return accounts
+}
+
+// TODO: extract to external library along with its counterpart in https://github.com/web3-storage/w3protocol/blob/main/packages/access-client/src/utils/did-mailto.js
+function createEmailFromDidMailto (did) {
+  const parts = did.split(':')
+  return `${parts[3]}@${parts[2]}`
+}
+
 /**
  * @param {string} email
  */
 export async function registerSpace (email) {
   const client = await getClient()
+  let accountEmail = email
+  if (!accountEmail) {
+    const accounts = findAccountsThatCanProviderAdd(client)
+    if (accounts.length === 1) {
+      accountEmail = createEmailFromDidMailto(accounts[0])
+    } else {
+      if (accounts.length > 1) {
+        console.error('Error: you are authorized to use more than one account and have not specified which one you would like to use to register this space. ')
+      } else {
+        console.error('Error: please authorize before registering spaces')
+      }
+      process.exit(1)
+    }
+  }
   let space = client.currentSpace()
   if (space === undefined) {
     space = await client.createSpace()
@@ -172,18 +207,20 @@ export async function registerSpace (email) {
   const spinner = ora('registering your space').start()
 
   try {
-    await client.registerSpace(email)
+    await client.registerSpace(accountEmail)
   } catch (err) {
     if (spinner) spinner.stop()
     if (err.message.startsWith('Space already registered')) {
       console.error('Error: space already registered.')
+    } else if (err.message.startsWith('no proofs available')) {
+      console.error(`Error: you are not authorized as ${accountEmail}`)
     } else {
       console.error(err)
     }
     process.exit(1)
   }
   if (spinner) spinner.stop()
-  console.log(`⁂ space registered to ${email}`)
+  console.log(`⁂ space registered to ${accountEmail}`)
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -181,8 +181,9 @@ function createEmailFromDidMailto (did) {
 
 /**
  * @param {string} email
+ * @param {string} [opts.provider]
  */
-export async function registerSpace (email) {
+export async function registerSpace (email, opts) {
   const client = await getClient()
   let accountEmail = email
   if (!accountEmail) {
@@ -207,7 +208,7 @@ export async function registerSpace (email) {
   const spinner = ora('registering your space').start()
 
   try {
-    await client.registerSpace(accountEmail)
+    await client.registerSpace(accountEmail, { provider: opts.provider })
   } catch (err) {
     if (spinner) spinner.stop()
     if (err.message.startsWith('Space already registered')) {

--- a/index.js
+++ b/index.js
@@ -180,19 +180,19 @@ function createEmailFromDidMailto (did) {
 }
 
 /**
- * @param {string} email
+ * @param {string} [opts.email]
  * @param {string} [opts.provider]
  */
-export async function registerSpace (email, opts) {
+export async function registerSpace (opts) {
   const client = await getClient()
-  let accountEmail = email
+  let accountEmail = opts.email
   if (!accountEmail) {
     const accounts = findAccountsThatCanProviderAdd(client)
     if (accounts.length === 1) {
       accountEmail = createEmailFromDidMailto(accounts[0])
     } else {
       if (accounts.length > 1) {
-        console.error('Error: you are authorized to use more than one account and have not specified which one you would like to use to register this space. ')
+        console.error('Error: you are authorized to use more than one account and have not specified which one you would like to use to register this space.')
       } else {
         console.error('Error: please authorize before registering spaces')
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.2.2",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@ipld/car": "^5.0.1",
+        "@ipld/car": "^5.1.1",
         "@ipld/dag-ucan": "^3.0.1",
-        "@ucanto/client": "^4.0.3",
-        "@ucanto/core": "^4.0.3",
-        "@ucanto/transport": "^4.0.3",
+        "@ucanto/client": "^5.1.0",
+        "@ucanto/core": "^5.2.0",
+        "@ucanto/transport": "^5.1.1",
         "@web3-storage/access": "11.0.0-rc.0",
         "@web3-storage/w3up-client": "^4.3.0",
         "files-from-path": "^1.0.0",
@@ -27,9 +27,9 @@
         "w3up": "shim.js"
       },
       "devDependencies": {
-        "@ucanto/principal": "^4.0.3",
-        "@ucanto/server": "^4.0.3",
-        "@web3-storage/capabilities": "^2.1.0",
+        "@ucanto/principal": "^5.1.0",
+        "@ucanto/server": "^6.1.0",
+        "@web3-storage/capabilities": "^4.0.0",
         "ava": "^5.1.0",
         "execa": "^6.1.0",
         "multiformats": "^11.0.0",
@@ -116,9 +116,9 @@
       "dev": true
     },
     "node_modules/@ipld/car": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.0.tgz",
-      "integrity": "sha512-k9pO0YqJvmFGY5pJDhF2Ocz+mRp3C3r4ikr1NrUXkzN/z4JzhE7XbQzUCcm7daq8k4tRqap0fWPjxZwjS9PUcQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.1.tgz",
+      "integrity": "sha512-HoFTUqUJL9cPGhC9qRmHCvamfIsj1JllQSQ/Xu9/KN/VNJp8To9Ms4qiZPEMOwcrNFclfYqrahjGYbf4KL/d9A==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
@@ -331,96 +331,80 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/@ucanto/client": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-4.2.3.tgz",
-      "integrity": "sha512-vIa0drEAeolQpSePpHtsW1bx8lzDdxtXi2fEdQ4f34xbI2VSOQuAgUURJTtRVmRXa5MweQoEGI9CHPKL4CMyFQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
+      "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
       "dependencies": {
-        "@ucanto/interface": "^4.1.0",
+        "@ucanto/interface": "^6.0.0",
         "multiformats": "^11.0.0"
       }
     },
     "node_modules/@ucanto/core": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-4.2.3.tgz",
-      "integrity": "sha512-udvp7IMRCE3XFhPYiKISt52r8QjbrqG7d1papdtWwF6RAzTbIWhgXSwAjEbroYCr/gQst7U8aYsgr4xvG2miUQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
       "dependencies": {
-        "@ipld/car": "^5.0.3",
+        "@ipld/car": "^5.1.0",
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-ucan": "^3.2.0",
-        "@ucanto/interface": "^4.1.0",
+        "@ucanto/interface": "^6.2.0",
         "multiformats": "^11.0.0"
       }
     },
     "node_modules/@ucanto/interface": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-4.2.3.tgz",
-      "integrity": "sha512-IoccqMc2/vqaPT6U061ylC138mQ3pLp6coqjXTDmlL9OHmskLcEeQh5Mxe0AYHWMhO1ZuB0LRIysBXk7xoK25Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
+      "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.2.0",
         "multiformats": "^11.0.0"
       }
     },
     "node_modules/@ucanto/principal": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-4.2.3.tgz",
-      "integrity": "sha512-S02cKaMcIQhxk9uJfUCUb+f98zEEFsC+5BZC6aBoYVCEpXwVZD6+hc9xI0yIQl8zJyQVA3nnUUpLfLynsSox2A==",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
+      "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.2.0",
-        "@noble/ed25519": "^1.7.1",
-        "@ucanto/interface": "^4.1.0",
+        "@noble/ed25519": "^1.7.3",
+        "@ucanto/interface": "^6.0.0",
         "multiformats": "^11.0.0",
         "one-webcrypto": "^1.0.3"
       }
     },
     "node_modules/@ucanto/server": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-4.2.3.tgz",
-      "integrity": "sha512-lmDC0d9mVGYfiqwzpiTG6CFZpGVw1GnFx9EOtozKPa+v2nzwqDAkwYAQwNrJ2nbJWQQeFi7/Jiaec9EmdPEpsg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-6.1.0.tgz",
+      "integrity": "sha512-IRvYbv1iEAjgm8Rc4hqUPm2NGSU+R+X+wyHp3hUI/YdGji+bajghV4gU9klkDkgm0aqVuI1fDFyODWZb5UROtw==",
       "dev": true,
       "dependencies": {
-        "@ucanto/core": "^4.1.0",
-        "@ucanto/interface": "^4.1.0",
-        "@ucanto/validator": "^4.1.0"
+        "@ucanto/core": "^5.1.0",
+        "@ucanto/interface": "^6.1.0",
+        "@ucanto/validator": "^6.1.0"
       }
     },
     "node_modules/@ucanto/transport": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-4.2.3.tgz",
-      "integrity": "sha512-ZtHB5ybSB/1dBLhzJqjxGDEE+TTTNzc9HMrVA1AP5KHvaHPu2UtAmS2IMr+HrhSjcwWwdavK0qMQbXSfLWM+kg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
+      "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
       "dependencies": {
-        "@ipld/car": "^5.0.3",
+        "@ipld/car": "^5.1.0",
         "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^4.1.0",
-        "@ucanto/interface": "^4.1.0",
+        "@ucanto/core": "^5.2.0",
+        "@ucanto/interface": "^6.2.0",
         "multiformats": "^11.0.0"
       }
     },
     "node_modules/@ucanto/validator": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-4.2.3.tgz",
-      "integrity": "sha512-7lA9PK+c0Hu857eHuZIVX3ZBooqvOT25/CXUxGjqs5YFCY7dUhrNCxJYnWsPZnEdriq6x6VSj8pZPwN8I7CyQw==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
+      "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
       "dependencies": {
-        "@ipld/car": "^5.0.3",
-        "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^4.1.0",
-        "@ucanto/interface": "^4.1.0",
+        "@ipld/car": "^5.1.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ucanto/core": "^5.1.0",
+        "@ucanto/interface": "^6.1.0",
         "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@ucanto/validator/node_modules/@ipld/dag-cbor": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
-      "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
-      "dev": true,
-      "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@web-std/stream": {
@@ -466,73 +450,7 @@
         "w3access": "src/cli/index.js"
       }
     },
-    "node_modules/@web3-storage/access/node_modules/@ucanto/client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
-      "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
-      "dependencies": {
-        "@ucanto/interface": "^6.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/access/node_modules/@ucanto/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-ucan": "^3.2.0",
-        "@ucanto/interface": "^6.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/access/node_modules/@ucanto/interface": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
-      "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
-      "dependencies": {
-        "@ipld/dag-ucan": "^3.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/access/node_modules/@ucanto/principal": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
-      "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
-      "dependencies": {
-        "@ipld/dag-ucan": "^3.2.0",
-        "@noble/ed25519": "^1.7.3",
-        "@ucanto/interface": "^6.0.0",
-        "multiformats": "^11.0.0",
-        "one-webcrypto": "^1.0.3"
-      }
-    },
-    "node_modules/@web3-storage/access/node_modules/@ucanto/transport": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
-      "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^5.2.0",
-        "@ucanto/interface": "^6.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/access/node_modules/@ucanto/validator": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
-      "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^5.1.0",
-        "@ucanto/interface": "^6.1.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/access/node_modules/@web3-storage/capabilities": {
+    "node_modules/@web3-storage/capabilities": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-4.0.0.tgz",
       "integrity": "sha512-O+WmApepwaNFNsOj8f66HrIgDl/VGsGLn4iJMyqZdiTxVupNXfFsSVI2iBGEaJlNI+RDzISejXnGtScy1abxGQ==",
@@ -542,19 +460,6 @@
         "@ucanto/principal": "^5.1.0",
         "@ucanto/transport": "^5.1.1",
         "@ucanto/validator": "^6.1.0"
-      }
-    },
-    "node_modules/@web3-storage/capabilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-2.3.0.tgz",
-      "integrity": "sha512-+vg61eqK1eqQ+QD1hvChDDx6CXLGFnUsEA+W+g9yagCpq+H9yAqROncEEt+oluIGvAqNbFMrUb+bWRWxk0Tmuw==",
-      "dev": true,
-      "dependencies": {
-        "@ucanto/core": "^4.2.3",
-        "@ucanto/interface": "^4.2.3",
-        "@ucanto/principal": "^4.2.3",
-        "@ucanto/transport": "^4.2.3",
-        "@ucanto/validator": "^4.2.3"
       }
     },
     "node_modules/@web3-storage/upload-client": {
@@ -572,72 +477,6 @@
         "multiformats": "^11.0.1",
         "p-queue": "^7.3.0",
         "p-retry": "^5.1.2"
-      }
-    },
-    "node_modules/@web3-storage/upload-client/node_modules/@ucanto/client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
-      "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
-      "dependencies": {
-        "@ucanto/interface": "^6.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/upload-client/node_modules/@ucanto/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-ucan": "^3.2.0",
-        "@ucanto/interface": "^6.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/upload-client/node_modules/@ucanto/interface": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
-      "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
-      "dependencies": {
-        "@ipld/dag-ucan": "^3.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/upload-client/node_modules/@ucanto/principal": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
-      "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
-      "dependencies": {
-        "@ipld/dag-ucan": "^3.2.0",
-        "@noble/ed25519": "^1.7.3",
-        "@ucanto/interface": "^6.0.0",
-        "multiformats": "^11.0.0",
-        "one-webcrypto": "^1.0.3"
-      }
-    },
-    "node_modules/@web3-storage/upload-client/node_modules/@ucanto/transport": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
-      "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^5.2.0",
-        "@ucanto/interface": "^6.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/upload-client/node_modules/@ucanto/validator": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
-      "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^5.1.0",
-        "@ucanto/interface": "^6.1.0",
-        "multiformats": "^11.0.0"
       }
     },
     "node_modules/@web3-storage/upload-client/node_modules/@web3-storage/capabilities": {
@@ -666,84 +505,6 @@
         "@web3-storage/access": "11.0.0-rc.0",
         "@web3-storage/capabilities": "^4.0.0",
         "@web3-storage/upload-client": "^7.0.0"
-      }
-    },
-    "node_modules/@web3-storage/w3up-client/node_modules/@ucanto/client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
-      "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
-      "dependencies": {
-        "@ucanto/interface": "^6.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/w3up-client/node_modules/@ucanto/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-ucan": "^3.2.0",
-        "@ucanto/interface": "^6.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/w3up-client/node_modules/@ucanto/interface": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
-      "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
-      "dependencies": {
-        "@ipld/dag-ucan": "^3.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/w3up-client/node_modules/@ucanto/principal": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
-      "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
-      "dependencies": {
-        "@ipld/dag-ucan": "^3.2.0",
-        "@noble/ed25519": "^1.7.3",
-        "@ucanto/interface": "^6.0.0",
-        "multiformats": "^11.0.0",
-        "one-webcrypto": "^1.0.3"
-      }
-    },
-    "node_modules/@web3-storage/w3up-client/node_modules/@ucanto/transport": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
-      "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^5.2.0",
-        "@ucanto/interface": "^6.2.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/w3up-client/node_modules/@ucanto/validator": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
-      "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^5.1.0",
-        "@ucanto/interface": "^6.1.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "node_modules/@web3-storage/w3up-client/node_modules/@web3-storage/capabilities": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-4.0.0.tgz",
-      "integrity": "sha512-O+WmApepwaNFNsOj8f66HrIgDl/VGsGLn4iJMyqZdiTxVupNXfFsSVI2iBGEaJlNI+RDzISejXnGtScy1abxGQ==",
-      "dependencies": {
-        "@ucanto/core": "^5.2.0",
-        "@ucanto/interface": "^6.2.0",
-        "@ucanto/principal": "^5.1.0",
-        "@ucanto/transport": "^5.1.1",
-        "@ucanto/validator": "^6.1.0"
       }
     },
     "node_modules/acorn": {
@@ -6356,9 +6117,9 @@
       "dev": true
     },
     "@ipld/car": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.0.tgz",
-      "integrity": "sha512-k9pO0YqJvmFGY5pJDhF2Ocz+mRp3C3r4ikr1NrUXkzN/z4JzhE7XbQzUCcm7daq8k4tRqap0fWPjxZwjS9PUcQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.1.tgz",
+      "integrity": "sha512-HoFTUqUJL9cPGhC9qRmHCvamfIsj1JllQSQ/Xu9/KN/VNJp8To9Ms4qiZPEMOwcrNFclfYqrahjGYbf4KL/d9A==",
       "requires": {
         "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
@@ -6536,94 +6297,80 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "@ucanto/client": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-4.2.3.tgz",
-      "integrity": "sha512-vIa0drEAeolQpSePpHtsW1bx8lzDdxtXi2fEdQ4f34xbI2VSOQuAgUURJTtRVmRXa5MweQoEGI9CHPKL4CMyFQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
+      "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
       "requires": {
-        "@ucanto/interface": "^4.1.0",
+        "@ucanto/interface": "^6.0.0",
         "multiformats": "^11.0.0"
       }
     },
     "@ucanto/core": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-4.2.3.tgz",
-      "integrity": "sha512-udvp7IMRCE3XFhPYiKISt52r8QjbrqG7d1papdtWwF6RAzTbIWhgXSwAjEbroYCr/gQst7U8aYsgr4xvG2miUQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
       "requires": {
-        "@ipld/car": "^5.0.3",
+        "@ipld/car": "^5.1.0",
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-ucan": "^3.2.0",
-        "@ucanto/interface": "^4.1.0",
+        "@ucanto/interface": "^6.2.0",
         "multiformats": "^11.0.0"
       }
     },
     "@ucanto/interface": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-4.2.3.tgz",
-      "integrity": "sha512-IoccqMc2/vqaPT6U061ylC138mQ3pLp6coqjXTDmlL9OHmskLcEeQh5Mxe0AYHWMhO1ZuB0LRIysBXk7xoK25Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
+      "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
       "requires": {
         "@ipld/dag-ucan": "^3.2.0",
         "multiformats": "^11.0.0"
       }
     },
     "@ucanto/principal": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-4.2.3.tgz",
-      "integrity": "sha512-S02cKaMcIQhxk9uJfUCUb+f98zEEFsC+5BZC6aBoYVCEpXwVZD6+hc9xI0yIQl8zJyQVA3nnUUpLfLynsSox2A==",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
+      "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
       "requires": {
         "@ipld/dag-ucan": "^3.2.0",
-        "@noble/ed25519": "^1.7.1",
-        "@ucanto/interface": "^4.1.0",
+        "@noble/ed25519": "^1.7.3",
+        "@ucanto/interface": "^6.0.0",
         "multiformats": "^11.0.0",
         "one-webcrypto": "^1.0.3"
       }
     },
     "@ucanto/server": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-4.2.3.tgz",
-      "integrity": "sha512-lmDC0d9mVGYfiqwzpiTG6CFZpGVw1GnFx9EOtozKPa+v2nzwqDAkwYAQwNrJ2nbJWQQeFi7/Jiaec9EmdPEpsg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-6.1.0.tgz",
+      "integrity": "sha512-IRvYbv1iEAjgm8Rc4hqUPm2NGSU+R+X+wyHp3hUI/YdGji+bajghV4gU9klkDkgm0aqVuI1fDFyODWZb5UROtw==",
       "dev": true,
       "requires": {
-        "@ucanto/core": "^4.1.0",
-        "@ucanto/interface": "^4.1.0",
-        "@ucanto/validator": "^4.1.0"
+        "@ucanto/core": "^5.1.0",
+        "@ucanto/interface": "^6.1.0",
+        "@ucanto/validator": "^6.1.0"
       }
     },
     "@ucanto/transport": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-4.2.3.tgz",
-      "integrity": "sha512-ZtHB5ybSB/1dBLhzJqjxGDEE+TTTNzc9HMrVA1AP5KHvaHPu2UtAmS2IMr+HrhSjcwWwdavK0qMQbXSfLWM+kg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
+      "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
       "requires": {
-        "@ipld/car": "^5.0.3",
+        "@ipld/car": "^5.1.0",
         "@ipld/dag-cbor": "^9.0.0",
-        "@ucanto/core": "^4.1.0",
-        "@ucanto/interface": "^4.1.0",
+        "@ucanto/core": "^5.2.0",
+        "@ucanto/interface": "^6.2.0",
         "multiformats": "^11.0.0"
       }
     },
     "@ucanto/validator": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-4.2.3.tgz",
-      "integrity": "sha512-7lA9PK+c0Hu857eHuZIVX3ZBooqvOT25/CXUxGjqs5YFCY7dUhrNCxJYnWsPZnEdriq6x6VSj8pZPwN8I7CyQw==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
+      "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
       "requires": {
-        "@ipld/car": "^5.0.3",
-        "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^4.1.0",
-        "@ucanto/interface": "^4.1.0",
+        "@ipld/car": "^5.1.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ucanto/core": "^5.1.0",
+        "@ucanto/interface": "^6.1.0",
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "@ipld/dag-cbor": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
-          "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
-          "dev": true,
-          "requires": {
-            "cborg": "^1.6.0",
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "@web-std/stream": {
@@ -6664,99 +6411,18 @@
         "varint": "^6.0.0",
         "ws": "^8.12.0",
         "zod": "^3.20.2"
-      },
-      "dependencies": {
-        "@ucanto/client": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
-          "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
-          "requires": {
-            "@ucanto/interface": "^6.0.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/core": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
-          "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ipld/dag-ucan": "^3.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/interface": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
-          "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
-          "requires": {
-            "@ipld/dag-ucan": "^3.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/principal": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
-          "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
-          "requires": {
-            "@ipld/dag-ucan": "^3.2.0",
-            "@noble/ed25519": "^1.7.3",
-            "@ucanto/interface": "^6.0.0",
-            "multiformats": "^11.0.0",
-            "one-webcrypto": "^1.0.3"
-          }
-        },
-        "@ucanto/transport": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
-          "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ucanto/core": "^5.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/validator": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
-          "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ucanto/core": "^5.1.0",
-            "@ucanto/interface": "^6.1.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@web3-storage/capabilities": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-4.0.0.tgz",
-          "integrity": "sha512-O+WmApepwaNFNsOj8f66HrIgDl/VGsGLn4iJMyqZdiTxVupNXfFsSVI2iBGEaJlNI+RDzISejXnGtScy1abxGQ==",
-          "requires": {
-            "@ucanto/core": "^5.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "@ucanto/principal": "^5.1.0",
-            "@ucanto/transport": "^5.1.1",
-            "@ucanto/validator": "^6.1.0"
-          }
-        }
       }
     },
     "@web3-storage/capabilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-2.3.0.tgz",
-      "integrity": "sha512-+vg61eqK1eqQ+QD1hvChDDx6CXLGFnUsEA+W+g9yagCpq+H9yAqROncEEt+oluIGvAqNbFMrUb+bWRWxk0Tmuw==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-4.0.0.tgz",
+      "integrity": "sha512-O+WmApepwaNFNsOj8f66HrIgDl/VGsGLn4iJMyqZdiTxVupNXfFsSVI2iBGEaJlNI+RDzISejXnGtScy1abxGQ==",
       "requires": {
-        "@ucanto/core": "^4.2.3",
-        "@ucanto/interface": "^4.2.3",
-        "@ucanto/principal": "^4.2.3",
-        "@ucanto/transport": "^4.2.3",
-        "@ucanto/validator": "^4.2.3"
+        "@ucanto/core": "^5.2.0",
+        "@ucanto/interface": "^6.2.0",
+        "@ucanto/principal": "^5.1.0",
+        "@ucanto/transport": "^5.1.1",
+        "@ucanto/validator": "^6.1.0"
       }
     },
     "@web3-storage/upload-client": {
@@ -6776,72 +6442,6 @@
         "p-retry": "^5.1.2"
       },
       "dependencies": {
-        "@ucanto/client": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
-          "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
-          "requires": {
-            "@ucanto/interface": "^6.0.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/core": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
-          "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ipld/dag-ucan": "^3.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/interface": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
-          "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
-          "requires": {
-            "@ipld/dag-ucan": "^3.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/principal": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
-          "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
-          "requires": {
-            "@ipld/dag-ucan": "^3.2.0",
-            "@noble/ed25519": "^1.7.3",
-            "@ucanto/interface": "^6.0.0",
-            "multiformats": "^11.0.0",
-            "one-webcrypto": "^1.0.3"
-          }
-        },
-        "@ucanto/transport": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
-          "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ucanto/core": "^5.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/validator": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
-          "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ucanto/core": "^5.1.0",
-            "@ucanto/interface": "^6.1.0",
-            "multiformats": "^11.0.0"
-          }
-        },
         "@web3-storage/capabilities": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-3.2.0.tgz",
@@ -6870,86 +6470,6 @@
         "@web3-storage/access": "11.0.0-rc.0",
         "@web3-storage/capabilities": "^4.0.0",
         "@web3-storage/upload-client": "^7.0.0"
-      },
-      "dependencies": {
-        "@ucanto/client": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-5.1.0.tgz",
-          "integrity": "sha512-Rr2q3ARDmiaaVnvNkPNsIhS+1ORyCqQhGRSqf8ugfJVmvbvjLFA6EYxjknUdg5tqt0aVnYTNuZ/GwIxaqMzliA==",
-          "requires": {
-            "@ucanto/interface": "^6.0.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/core": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-5.2.0.tgz",
-          "integrity": "sha512-Eblo2LfJyojRKmBk5/w25u1hhSCs6K3zUH/zNknwTrJg7CJYxw0hgsGcXrlkQf1TnSRzJVFEduK1ZzYCV55/Uw==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ipld/dag-ucan": "^3.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/interface": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-6.2.0.tgz",
-          "integrity": "sha512-b37bjTxNWQE+O4f18fvb7/woe41Dvb4AfdbevPLmaJj1fZogssH9fVgWlZdVg8ZsJQhMxRyHDuH40QAvuKRR1w==",
-          "requires": {
-            "@ipld/dag-ucan": "^3.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/principal": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-5.1.0.tgz",
-          "integrity": "sha512-niZzojYPYAgdszTmra82wGbl5YGHugUblMTPrEjuz3RFjXDCxW50IJFwzus3Z6k6Q6zIbXPU+yVxTbzJWg8/JA==",
-          "requires": {
-            "@ipld/dag-ucan": "^3.2.0",
-            "@noble/ed25519": "^1.7.3",
-            "@ucanto/interface": "^6.0.0",
-            "multiformats": "^11.0.0",
-            "one-webcrypto": "^1.0.3"
-          }
-        },
-        "@ucanto/transport": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-5.1.1.tgz",
-          "integrity": "sha512-5g2Xiofqalvmaw/UPRTdxV2be+KE3TMbFhG4ZNNPkDIBpdBduVENcLQPJ9ksD29Bc2ArIefXALxGzyGLgUPCBg==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ucanto/core": "^5.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@ucanto/validator": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-6.1.0.tgz",
-          "integrity": "sha512-vZ40paByLgosllG+YfuI4eD7m3KyYG1ebEa9jZEkLDYjWh7WWBtYvBn40pziIiLfBCzum2zU1uP1SMOf63EqqQ==",
-          "requires": {
-            "@ipld/car": "^5.1.0",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ucanto/core": "^5.1.0",
-            "@ucanto/interface": "^6.1.0",
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@web3-storage/capabilities": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-4.0.0.tgz",
-          "integrity": "sha512-O+WmApepwaNFNsOj8f66HrIgDl/VGsGLn4iJMyqZdiTxVupNXfFsSVI2iBGEaJlNI+RDzISejXnGtScy1abxGQ==",
-          "requires": {
-            "@ucanto/core": "^5.2.0",
-            "@ucanto/interface": "^6.2.0",
-            "@ucanto/principal": "^5.1.0",
-            "@ucanto/transport": "^5.1.1",
-            "@ucanto/validator": "^6.1.0"
-          }
-        }
       }
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "homepage": "https://github.com/web3-storage/w3cli#readme",
   "devDependencies": {
-    "@ucanto/principal": "^4.0.3",
-    "@ucanto/server": "^4.0.3",
-    "@web3-storage/capabilities": "^2.1.0",
+    "@ucanto/principal": "^5.1.0",
+    "@ucanto/server": "^6.1.0",
+    "@web3-storage/capabilities": "^4.0.0",
     "ava": "^5.1.0",
     "execa": "^6.1.0",
     "multiformats": "^11.0.0",
@@ -43,11 +43,11 @@
     "standard": "^17.0.0"
   },
   "dependencies": {
-    "@ipld/car": "^5.0.1",
+    "@ipld/car": "^5.1.1",
     "@ipld/dag-ucan": "^3.0.1",
-    "@ucanto/client": "^4.0.3",
-    "@ucanto/core": "^4.0.3",
-    "@ucanto/transport": "^4.0.3",
+    "@ucanto/client": "^5.1.0",
+    "@ucanto/core": "^5.2.0",
+    "@ucanto/transport": "^5.1.1",
     "@web3-storage/access": "11.0.0-rc.0",
     "@web3-storage/w3up-client": "^4.3.0",
     "files-from-path": "^1.0.0",


### PR DESCRIPTION
If we're only authorized to act as a single account we shouldn't need to pass an email address to `space register` since we can infer which one to use from the delegations we currently have.

Preserve the ability to pass email using the `--email` option for cases where we are authorized as multiple accounts.

Also add a `--provider` option to `space register` to allow users to register spaces with other providers like NFT.Storage.