### PR TITLE
feat: show help text if no cmd

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -31,7 +31,14 @@ const cli = sade('w3')
 
 cli
   .version(getPkg().version)
+  .example('authorize user@example.com')
   .example('up path/to/files')
+
+cli.command('authorize <email>')
+  .alias('auth')
+  .example('authorize user@example.com')
+  .describe('Authorize this agent to interact with the w3up service with any capabilities granted to the given email.')
+  .action(authorize)
 
 cli.command('up <file>')
   .alias('upload', 'put')
@@ -59,12 +66,6 @@ cli.command('rm <root-cid>')
   .describe('Remove an upload from the uploads listing. Pass --shards to delete the actual data if you are sure no other uploads need them')
   .option('--shards', 'Remove all shards referenced by the upload from the store. Use with caution and ensure other uploads do not reference the same shards.')
   .action(remove)
-
-cli.command('authorize <email>')
-  .alias('auth')
-  .example('authorize user@example.com')
-  .describe('Authorize this agent to interact with the w3up service with any capabilities granted to the given email.')
-  .action(authorize)
 
 cli.command('whoami')
   .describe('Print information about the current agent.')
@@ -145,5 +146,21 @@ cli.command('can upload ls')
   .option('--cursor', 'An opaque string included in a prior upload/list response that allows the service to provide the next "page" of results')
   .option('--pre', 'If true, return the page of results preceding the cursor')
   .action(uploadList)
+
+// show help text if no command provided
+cli.command('help [cmd]', 'Show help text', { default: true })
+  .action(cmd => {
+    try {
+      cli.help(cmd)
+    } catch (err) {
+      console.log(`
+ERROR
+  Invalid command: ${cmd}
+  
+Run \`$ w3 --help\` for more info.
+`)
+      process.exit(1)
+    }
+  })
 
 cli.parse(process.argv)

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -84,7 +84,6 @@ test('w3 nosuchcmd', async (t) => {
     execaSync('./bin.js', ['nosuchcmd'], { env })
     t.fail('Expected to throw')
   } catch (err) {
-    // console.log(err)
     t.is(err.exitCode, 1)
     t.regex(err.stdout, /Invalid command: nosuch/)
   }

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -73,9 +73,21 @@ test.afterEach(async t => {
 })
 
 test('w3', async (t) => {
-  t.throws(() => {
-    execaSync('./bin.js')
-  }, { message: /No command specified./ })
+  const env = t.context.env.alice
+  const res = await execa('./bin.js', [], { env })
+  t.regex(res.stdout, /Available Commands/)
+})
+
+test('w3 nosuchcmd', async (t) => {
+  const env = t.context.env.alice
+  try {
+    execaSync('./bin.js', ['nosuchcmd'], { env })
+    t.fail('Expected to throw')
+  } catch (err) {
+    // console.log(err)
+    t.is(err.exitCode, 1)
+    t.regex(err.stdout, /Invalid command: nosuch/)
+  }
 })
 
 test('w3 --version', (t) => {


### PR DESCRIPTION
showing an error when users type `w3` is pretty jarring.

Adds a `help [cmd]` command which is set as the `default` so it runs when no command is provided. If it's run with a command that isn't registered it produces the same output as sade would normally (ERROR: Invalid command)


**before (boo, hiss)**
```sh
❯ w3

  ERROR
    No command specified.

  Run `$ w3 --help` for more info.
```

**after**
```sh
❯ ./bin.js

  Usage
    $ w3 <command> [options]

  Available Commands
    authorize            Authorize this agent to interact with the w3up service with any capabilities granted to the given email.
    up                   Store a file(s) to the service and register an upload.
    open                 Open CID on https://w3s.link
    ls                   List uploads in the current space
    rm                   Remove an upload from the uploads listing.
    whoami               Print information about the current agent.
    space create         Create a new w3 space
    space register       Claim the space by associating it with your email address
    space add            Add a space to the agent.
    space ls             List spaces known to the agent
    space use            Set the current space in use by the agent
    delegation create    Create a delegation to the passed audience for the given abilities with the _current_ space as the resource.
    delegation ls        List delegations created by this agent for others.
    proof add            Add a proof delegated to this agent.
    proof ls             List proofs of capabilities delegated to this agent.
    can access claim     Claim delegated capabilities for the authorized account.
    can store add        Store a CAR file with the service.
    can store ls         List CAR files in the current space.
    can upload add       Register an upload - a DAG with the given root data CID that is stored in the given CAR shard(s), identified by CAR CIDs.
    can upload ls        List uploads in the current space.
    help                 Show help text

  For more info, run any command with the `--help` flag
    $ w3 authorize --help
    $ w3 up --help

  Options
    -v, --version    Displays current version
    -h, --help       Displays this message

  Examples
    $ w3 authorize user@example.com
    $ w3 up path/to/files
```


License: MIT