### PR TITLE
feat: add ability to specify custom principal

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -5,6 +5,7 @@ import { importDAG } from '@ucanto/core/delegation'
 import { connect } from '@ucanto/client'
 import * as CAR from '@ucanto/transport/car'
 import * as HTTP from '@ucanto/transport/http'
+import * as Signer from '@ucanto/principal/ed25519'
 import { parse } from '@ipld/dag-ucan/did'
 import { create } from '@web3-storage/w3up-client'
 import { StoreConf } from '@web3-storage/access/stores/store-conf'
@@ -74,7 +75,14 @@ export function getClient () {
     }
   }
 
-  return create({ store, serviceConf })
+  const createConfig = { store, serviceConf }
+
+  const principal = process.env.W3_PRINCIPAL
+  if (principal) {
+    createConfig.principal = Signer.parse(principal)
+  }
+
+  return create(createConfig)
 }
 
 /**


### PR DESCRIPTION
This is needed by one of the teams integrating with w3up. 

w3up-client will already fail if you pass a different principal than the store is configured to use, so we don't need to add any extra validation logic - end-users can generate a key with `npx ucan-key ed --json` and set the `W3_PRINCIPAL` environment variable for at least the first invocation of `w3` in a new environment. 

Setting `W3_PRINCIPAL` on subsequent invocations is optional but will ensure the principal used by the client is always the same.