### PR TITLE
fix: don't error when email address contains +

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ import { getClient, checkPathsExist, filesize, readProof, uploadListResponseToSt
 import * as ucanto from '@ucanto/core'
 import * as DidMailto from '@web3-storage/did-mailto'
 
-
 export async function accessClaim () {
   const client = await getClient()
   await client.capability.access.claim()

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ import { CarWriter } from '@ipld/car'
 import { filesFromPaths } from 'files-from-path'
 import { getClient, checkPathsExist, filesize, readProof, uploadListResponseToString } from './lib.js'
 import * as ucanto from '@ucanto/core'
+import * as DidMailto from '@web3-storage/did-mailto'
+
 
 export async function accessClaim () {
   const client = await getClient()
@@ -178,12 +180,6 @@ function findAccountsThatCanProviderAdd (client) {
   return accounts
 }
 
-// TODO: extract to external library along with its counterpart in https://github.com/web3-storage/w3protocol/blob/main/packages/access-client/src/utils/did-mailto.js
-function createEmailFromDidMailto (did) {
-  const parts = did.split(':')
-  return `${parts[3]}@${parts[2]}`
-}
-
 /**
  * @param {string} [opts.email]
  * @param {string} [opts.provider]
@@ -194,7 +190,7 @@ export async function registerSpace (opts) {
   if (!accountEmail) {
     const accounts = findAccountsThatCanProviderAdd(client)
     if (accounts.length === 1) {
-      accountEmail = createEmailFromDidMailto(accounts[0])
+      accountEmail = DidMailto.toEmail(accounts[0])
     } else {
       if (accounts.length > 1) {
         console.error('Error: you are authorized to use more than one account and have not specified which one you would like to use to register this space.')

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@ucanto/core": "^8.0.0",
         "@ucanto/transport": "^8.0.0",
         "@web3-storage/access": "^15.1.1",
+        "@web3-storage/did-mailto": "^2.0.0",
         "@web3-storage/w3up-client": "^8.0.1",
         "files-from-path": "^1.0.0",
         "open": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@ucanto/core": "^8.0.0",
     "@ucanto/transport": "^8.0.0",
     "@web3-storage/access": "^15.1.1",
+    "@web3-storage/did-mailto": "^2.0.0",
     "@web3-storage/w3up-client": "^8.0.1",
     "files-from-path": "^1.0.0",
     "open": "^8.4.0",


### PR DESCRIPTION
fix a bug where registering a space after authorizing as an email address with a + character in the first part would escape the + to %2B