### PR TITLE
fix: do not print error when space is unknown

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,20 +281,31 @@ export async function spaceInfo (opts) {
   if (!spaceDID) {
     throw new Error('no current space and no space given: please use --space to specify a space or select one using "space use"')
   }
+
+  /** @type {import('@web3-storage/access/types').SpaceInfoResult} */
+  let info
   try {
-    const info = await client.capability.space.info(spaceDID)
-    if (opts.json) {
-      console.log(JSON.stringify(info, null, 4))
-    } else {
-      // @ts-expect-error https://github.com/web3-storage/w3up/pull/911
-      const providers = info.providers?.join(', ') ?? ''
-      console.log(`
-DID: ${info.did}
-Providers: ${providers}
-`)
-    }
+    info = await client.capability.space.info(spaceDID)
   } catch (/** @type {any} */err) {
-    console.log(`Error getting info about ${spaceDID}: ${err.message}`)
+    // if the space was not known to the service then that's ok, there's just
+    // no info to print about it. Don't make it look like something is wrong,
+    // just print the space DID since that's all we know.
+    if (err.name === 'SpaceUnknown') {
+      // @ts-expect-error spaceDID should be a did:key
+      info = { did: spaceDID }
+    } else {
+      return console.log(`Error getting info about ${spaceDID}: ${err.message}`)
+    }
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(info, null, 4))
+  } else {
+    const providers = info.providers?.join(', ') ?? ''
+    console.log(`
+      DID: ${info.did}
+Providers: ${providers || chalk.dim('none')}
+`)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ucanto/client": "^8.0.0",
         "@ucanto/core": "^8.0.0",
         "@ucanto/transport": "^8.0.0",
-        "@web3-storage/access": "^15.2.0",
+        "@web3-storage/access": "^15.2.1",
         "@web3-storage/did-mailto": "^2.0.0",
         "@web3-storage/w3up-client": "^8.0.2",
         "chalk": "^5.3.0",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@web3-storage/access": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-15.2.0.tgz",
-      "integrity": "sha512-515WwZZLs2M0Dau3JGgroyK0a6fcuREcFv+i2EjUMLW8neYP7k8j++rpOjBSUNIIHkBbYtqx2aeX6fzmmEPriw==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-15.2.1.tgz",
+      "integrity": "sha512-ROTg8tkgyT7wXnvzyA/k5L9fOK/26MH9gtmibkz03xsr1wLM8g4w/OuG4uSQ7c50Q91dux58TDCFHw2XsiG3+w==",
       "dependencies": {
         "@ipld/car": "^5.1.1",
         "@ipld/dag-ucan": "^3.3.2",
@@ -563,7 +563,7 @@
         "@ucanto/principal": "^8.0.0",
         "@ucanto/transport": "^8.0.0",
         "@ucanto/validator": "^8.0.0",
-        "@web3-storage/capabilities": "^9.2.0",
+        "@web3-storage/capabilities": "^9.3.0",
         "@web3-storage/did-mailto": "^2.0.0",
         "bigint-mod-arith": "^3.1.2",
         "conf": "10.2.0",
@@ -594,9 +594,9 @@
       }
     },
     "node_modules/@web3-storage/capabilities": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-9.2.1.tgz",
-      "integrity": "sha512-NBXm9320grYtKYV7g8nI7zzzS6GfOPp7EmDeWxDwOZ3nHvXDuiR77e3Sf7rRY265rMyJCtRUJ7/qRk7unQSfmA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-9.3.0.tgz",
+      "integrity": "sha512-z78CrQNyUfOr0+ZgV+lRs31DcrfRjFVLNOPqV7a1JVL42/j++ZpFVWRWdV1bvV7HFjx5WyT7GjXQULPpMF5GQQ==",
       "dependencies": {
         "@ucanto/core": "^8.0.0",
         "@ucanto/interface": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@ucanto/client": "^8.0.0",
     "@ucanto/core": "^8.0.0",
     "@ucanto/transport": "^8.0.0",
-    "@web3-storage/access": "^15.2.0",
+    "@web3-storage/access": "^15.2.1",
     "@web3-storage/did-mailto": "^2.0.0",
     "@web3-storage/w3up-client": "^8.0.2",
     "chalk": "^5.3.0",

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -479,6 +479,7 @@ test('w3 space info', async t => {
 
   /** @type {import('@web3-storage/w3up-client/types').DID<'key'>} */
   const spaceDID = 'did:key:abc123'
+  /** @type {import('@web3-storage/w3up-client/types').DID<'web'>} */
   const provider = 'did:web:test.web3.storage'
   const service = mockService({
     space: {
@@ -497,7 +498,7 @@ test('w3 space info', async t => {
   t.is(service.space.info.callCount, 1)
 
   t.is(stdout, `
-DID: ${spaceDID.toString()}
+      DID: ${spaceDID.toString()}
 Providers: ${provider}
 `)
 })


### PR DESCRIPTION
If the space was not known to the service then that's ok, there's just no info to print about it. Don't make it look like something is wrong, just print the space DID since that's all we know.

Also makes the output a bit nicer by adding a "none" when no providers, and aligning the labels centrally:

Without provider:

<img width="549" alt="Screenshot 2023-09-13 at 12 06 08" src="https://github.com/web3-storage/w3cli/assets/152863/e603f742-a4cc-4124-be12-f1a44128d4a6">

(Was previously printing `Error getting info about did:key:z6Mksjp3Mbe7TnQbYK43NECF7TRuDGZu9xdzeLg379Dw66mF: Space not found.`)

With provider:

<img width="495" alt="Screenshot 2023-09-13 at 12 06 15" src="https://github.com/web3-storage/w3cli/assets/152863/8b9e4c76-5517-4fe6-8f54-d92cee0a4578">

Note: I chose to address this here and not alter the service because I think it's probably useful to be able to distinguish programmatically between spaces that are known to the service and spaces that are not, however in this instance it's not haha!