### PR TITLE
feat: introduce unified service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ List uploads in the current space.
 
 ### `w3 can upload rm <root-cid>`
 
+## Environment Variables
+
+By default, `w3` will use the w3up service at https://up.web3.storage. If you would like
+to use a different w3up-compatible service, you can use the `W3UP_SERVICE_DID` and `W3UP_SERVICE_URL` environment variables to set the service DID and URL endpoint.
+
 ## FAQ
 
 ### Where are my keys and delegations stored?

--- a/lib.js
+++ b/lib.js
@@ -11,6 +11,7 @@ import { parse } from '@ipld/dag-ucan/did'
 import { create } from '@web3-storage/w3up-client'
 import { StoreConf } from '@web3-storage/access/stores/store-conf'
 import { CarReader } from '@ipld/car'
+import chalk from 'chalk'
 
 /**
  * @typedef {import('@web3-storage/w3up-client/types').FileLike & { size: number }} FileLike
@@ -54,28 +55,40 @@ export function filesizeMB (bytes) {
 export function getClient () {
   const store = new StoreConf({ profile: process.env.W3_STORE_NAME ?? 'w3cli' })
 
+  if (process.env.W3_ACCESS_SERVICE_URL || process.env.W3_UPLOAD_SERVICE_URL) {
+    console.warn(chalk.dim('warning: the W3_ACCESS_SERVICE_URL and W3_UPLOAD_SERVICE_URL environment variables are deprecated and will be removed in a future release - please use W3UP_SERVICE_URL instead.'))
+  }
+
+  if (process.env.W3_ACCESS_SERVICE_DID || process.env.W3_UPLOAD_SERVICE_DID) {
+    console.warn(chalk.dim('warning: the W3_ACCESS_SERVICE_DID and W3_UPLOAD_SERVICE_DID environment variables are deprecated and will be removed in a future release - please use W3UP_SERVICE_DID instead.'))
+  }
+
+  const accessServiceDID = process.env.W3UP_SERVICE_DID || process.env.W3_ACCESS_SERVICE_DID
+  const accessServiceURL = process.env.W3UP_SERVICE_URL || process.env.W3_ACCESS_SERVICE_URL
+  const uploadServiceDID = process.env.W3UP_SERVICE_DID || process.env.W3_UPLOAD_SERVICE_DID
+  const uploadServiceURL = process.env.W3UP_SERVICE_URL || process.env.W3_UPLOAD_SERVICE_URL
   let serviceConf
   if (
-    process.env.W3_ACCESS_SERVICE_DID &&
-    process.env.W3_ACCESS_SERVICE_URL &&
-    process.env.W3_UPLOAD_SERVICE_DID &&
-    process.env.W3_UPLOAD_SERVICE_URL
+    accessServiceDID &&
+    accessServiceURL &&
+    uploadServiceDID &&
+    uploadServiceURL
   ) {
     /** @type {import('@web3-storage/w3up-client/types').ServiceConf} */
     serviceConf = {
       access: connect({
-        id: parse(process.env.W3_ACCESS_SERVICE_DID),
+        id: parse(accessServiceDID),
         codec: CAR.outbound,
         channel: HTTP.open({
-          url: new URL(process.env.W3_ACCESS_SERVICE_URL),
+          url: new URL(accessServiceURL),
           method: 'POST'
         })
       }),
       upload: connect({
-        id: parse(process.env.W3_UPLOAD_SERVICE_DID),
+        id: parse(uploadServiceDID),
         codec: CAR.outbound,
         channel: HTTP.open({
-          url: new URL(process.env.W3_UPLOAD_SERVICE_URL),
+          url: new URL(uploadServiceURL),
           method: 'POST'
         })
       })

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -9,10 +9,8 @@ export function createEnv (options = {}) {
   const env = { W3_STORE_NAME: storeName ?? 'w3cli-test' }
   if (servicePrincipal && serviceURL) {
     Object.assign(env, {
-      W3_ACCESS_SERVICE_DID: servicePrincipal.did(),
-      W3_ACCESS_SERVICE_URL: serviceURL.toString(),
-      W3_UPLOAD_SERVICE_DID: servicePrincipal.did(),
-      W3_UPLOAD_SERVICE_URL: serviceURL.toString()
+      W3UP_SERVICE_DID: servicePrincipal.did(),
+      W3UP_SERVICE_URL: serviceURL.toString()
     })
   }
   return env


### PR DESCRIPTION
previously, `w3` users would need to set 4 environment variables (`W3_ACCESS_SERVICE_DID`, `W3_ACCESS_SERVICE_URL`, `W3_UPLOAD_SERVICE_DID` and `W3_UPLOAD_SERVICE_URL`) to connect to staging or development services. 

This allows them to use 2 environment variables: `W3UP_SERVICE_DID` and `W3UP_SERVICE_URL`.