### PR TITLE
feat: add `can store rm` & `can upload rm` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ List CARs in the current space.
 * `--cursor` An opaque string included in a prior upload/list response that allows the service to provide the next "page" of results
 * `--pre` If true, return the page of results preceding the cursor
 
-### `w3 can store rm <car-cid>`
+### `w3 can store rm <shard-cid>`
 
 Remove a CAR from the store.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ w3 up recipies.txt
   * [`w3 authorize`](#w3-authorize-email)
   * [`w3 up`](#w3-up-path-path)
   * [`w3 ls`](#w3-ls)
-  * [`w3 rm`](#w3-rm-root-cid) <sup>coming soon!</sup>
+  * [`w3 rm`](#w3-rm-root-cid)
   * [`w3 open`](#w3-open-cid)
   * [`w3 whoami`](#w3-whoami)
 * Space management
@@ -72,10 +72,10 @@ w3 up recipies.txt
   * [`w3 can space recover`](#w3-can-space-recover-email) <sup>coming soon!</sup>
   * [`w3 can store add`](#w3-can-store-add-car-path)
   * [`w3 can store ls`](#w3-can-store-ls)
-  * [`w3 can store rm`](#w3-can-store-rm-car-cid) <sup>coming soon!</sup>
+  * [`w3 can store rm`](#w3-can-store-rm-car-cid)
   * [`w3 can upload add`](#w3-can-upload-add-root-cid-shard-cid-shard-cid)
   * [`w3 can upload ls`](#w3-can-upload-ls)
-  * [`w3 can upload rm`](#w3-can-upload-rm-root-cid) <sup>coming soon!</sup>
+  * [`w3 can upload rm`](#w3-can-upload-rm-root-cid)
 
 ---
 
@@ -213,6 +213,8 @@ List CARs in the current space.
 
 ### `w3 can store rm <car-cid>`
 
+Remove a CAR from the store.
+
 ### `w3 can upload add <root-cid> <shard-cid> [shard-cid...]`
 
 Register an upload - a DAG with the given root data CID that is stored in the given CAR shard(s), identified by CAR CIDs.
@@ -228,6 +230,8 @@ List uploads in the current space.
 * `--pre` If true, return the page of results preceding the cursor
 
 ### `w3 can upload rm <root-cid>`
+
+Remove an upload from the current space's upload list. Does not remove CAR from the store.
 
 ## FAQ
 

--- a/bin.js
+++ b/bin.js
@@ -24,8 +24,10 @@ import {
 import {
   storeAdd,
   storeList,
+  storeRemove,
   uploadAdd,
-  uploadList
+  uploadList,
+  uploadRemove
 } from './can.js'
 
 const cli = sade('w3')
@@ -142,6 +144,10 @@ cli.command('can store ls')
   .option('--pre', 'If true, return the page of results preceding the cursor')
   .action(storeList)
 
+cli.command('can store rm <shard-cid>')
+  .describe('Remove a CAR shard from the store.')
+  .action(storeRemove)
+
 cli.command('can upload add <root-cid> <shard-cid>')
   .describe('Register an upload - a DAG with the given root data CID that is stored in the given CAR shard(s), identified by CAR CIDs.')
   .action(uploadAdd)
@@ -154,6 +160,10 @@ cli.command('can upload ls')
   .option('--cursor', 'An opaque string included in a prior upload/list response that allows the service to provide the next "page" of results')
   .option('--pre', 'If true, return the page of results preceding the cursor')
   .action(uploadList)
+
+cli.command('can upload rm <root-cid>')
+  .describe('Remove an upload from the uploads listing.')
+  .action(uploadRemove)
 
 // show help text if no command provided
 cli.command('help [cmd]', 'Show help text', { default: true })

--- a/can.js
+++ b/can.js
@@ -60,6 +60,7 @@ export async function storeList (opts = {}) {
 export async function storeRemove (cidStr) {
   const shard = parseCarLink(cidStr)
   if (!shard) {
+    console.error(`Error: ${cidStr} is not a CAR CID`)
     process.exit(1)
   }
   const client = await getClient()

--- a/lib.js
+++ b/lib.js
@@ -185,18 +185,9 @@ export function asCarLink (cid) {
 /**
  * Return validated CARLink type or exit the process with an error code and message
  * @param {string} cidStr
- * @param {object} console
- * @param {(msg: string) => void} console.error
  **/
-export function parseCarLink (cidStr, { error } = console) {
+export function parseCarLink (cidStr) {
   try {
-    const cid = CID.parse(cidStr.trim())
-    const car = asCarLink(cid)
-    if (car === undefined) {
-      error(`Error: ${cidStr} is not a CAR CID`)
-    }
-    return car
-  } catch (err) {
-    error(`Error: ${cidStr} is not a CID`)
-  }
+    return asCarLink(CID.parse(cidStr.trim()))
+  } catch {}
 }

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -18,6 +18,7 @@ import { mockService } from './helpers/mocks.js'
 import { createServer as createHTTPServer } from './helpers/http-server.js'
 import { createHTTPListener } from './helpers/ucanto.js'
 import { createEnv } from './helpers/env.js'
+import { AssertionError } from 'assert'
 
 /**
  * @typedef {{
@@ -700,6 +701,51 @@ test('w3 can upload ls', async (t) => {
   t.notThrows(() => Link.parse(JSON.parse(list1.stdout).root))
 })
 
+test('w3 can upload rm', async (t) => {
+  const env = t.context.env.alice
+
+  await execa('./bin.js', ['space', 'create'], { env })
+
+  /** @type {Array<import('@web3-storage/capabilities/types').UploadAdd['nb']>} */
+  const uploads = []
+
+  const service = mockService({
+    store: {
+      add: provide(StoreCapabilities.add, ({ capability }) => {
+        return ok(/** @type {StoreAddOk} */({
+          status: 'upload',
+          headers: { 'x-test': 'true' },
+          url: 'http://localhost:9200',
+          with: capability.with,
+          link: capability.nb.link
+        }))
+      })
+    },
+    upload: {
+      add: provide(UploadCapabilities.add, ({ invocation }) => {
+        const { nb } = invocation.capabilities[0]
+        if (!nb) throw new Error('missing nb')
+        uploads.push(nb)
+        return ok(nb)
+      }),
+      list: provide(UploadCapabilities.list, () => {
+        return ok({ results: uploads, size: uploads.length })
+      }),
+      remove: provide(UploadCapabilities.remove, () => {
+        return ok({})
+      })
+    }
+  })
+
+  t.context.setService(service)
+
+  await execa('./bin.js', ['up', 'test/fixtures/pinpie.jpg'], { env })
+
+  await t.throwsAsync(() => execa('./bin.js', ['can', 'upload', 'rm'], { env }), { message: /Insufficient arguments/ })
+  await t.throwsAsync(() => execa('./bin.js', ['can', 'upload', 'rm', 'foo'], { env }), { message: /not a CID/ })
+  await t.notThrowsAsync(() => execa('./bin.js', ['can', 'upload', 'rm', uploads[0].root.toString()], { env }))
+})
+
 test('w3 can store ls', async (t) => {
   const env = t.context.env.alice
 
@@ -743,4 +789,49 @@ test('w3 can store ls', async (t) => {
 
   const list1 = await execa('./bin.js', ['can', 'store', 'ls', '--json'], { env })
   t.notThrows(() => Link.parse(JSON.parse(list1.stdout).link))
+})
+
+test('w3 can store rm', async (t) => {
+  const env = t.context.env.alice
+
+  await execa('./bin.js', ['space', 'create'], { env })
+
+  /** @type {Array<import('@web3-storage/capabilities/types').UploadAdd['nb']>} */
+  const uploads = []
+
+  const service = mockService({
+    store: {
+      add: provide(StoreCapabilities.add, ({ capability }) => {
+        return ok(/** @type {StoreAddOk} */({
+          status: 'upload',
+          headers: { 'x-test': 'true' },
+          url: 'http://localhost:9200',
+          with: capability.with,
+          link: capability.nb.link
+        }))
+      }),
+      remove: provide(StoreCapabilities.remove, () => {
+        return ok({})
+      })
+    },
+    upload: {
+      add: provide(UploadCapabilities.add, ({ invocation }) => {
+        const { nb } = invocation.capabilities[0]
+        if (!nb) throw new Error('missing nb')
+        uploads.push(nb)
+        return ok(nb)
+      })
+    }
+  })
+
+  t.context.setService(service)
+
+  await execa('./bin.js', ['up', 'test/fixtures/pinpie.jpg'], { env })
+
+  const shard = uploads[0].shards?.at(0)
+  if (!shard) { return t.fail('mock shard should exist') }
+  await t.throwsAsync(() => execa('./bin.js', ['can', 'store', 'rm'], { env }), { message: /Insufficient arguments/ })
+  await t.throwsAsync(() => execa('./bin.js', ['can', 'store', 'rm', 'foo'], { env }), { message: /not a CID/ })
+  await t.throwsAsync(() => execa('./bin.js', ['can', 'store', 'rm', uploads[0].root.toString()], { env }), { message: /not a CAR CID/ })
+  await t.notThrowsAsync(() => execa('./bin.js', ['can', 'store', 'rm', shard.toString()], { env }))
 })

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -830,7 +830,7 @@ test('w3 can store rm', async (t) => {
   const shard = uploads[0].shards?.at(0)
   if (!shard) { return t.fail('mock shard should exist') }
   await t.throwsAsync(() => execa('./bin.js', ['can', 'store', 'rm'], { env }), { message: /Insufficient arguments/ })
-  await t.throwsAsync(() => execa('./bin.js', ['can', 'store', 'rm', 'foo'], { env }), { message: /not a CID/ })
+  await t.throwsAsync(() => execa('./bin.js', ['can', 'store', 'rm', 'foo'], { env }), { message: /not a CAR CID/ })
   await t.throwsAsync(() => execa('./bin.js', ['can', 'store', 'rm', uploads[0].root.toString()], { env }), { message: /not a CAR CID/ })
   await t.notThrowsAsync(() => execa('./bin.js', ['can', 'store', 'rm', shard.toString()], { env }))
 })

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -18,7 +18,6 @@ import { mockService } from './helpers/mocks.js'
 import { createServer as createHTTPServer } from './helpers/http-server.js'
 import { createHTTPListener } from './helpers/ucanto.js'
 import { createEnv } from './helpers/env.js'
-import { AssertionError } from 'assert'
 
 /**
  * @typedef {{

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -3,7 +3,9 @@ import * as Link from 'multiformats/link'
 import {
   filesize,
   uploadListResponseToString,
-  storeListResponseToString
+  storeListResponseToString,
+  asCarLink,
+  parseCarLink
 } from '../lib.js'
 
 /**
@@ -102,4 +104,25 @@ test('storeListResponseToString can return the CAR CIDs as newline delimited JSO
     `{"link":"bagbaierablvu5d2q5uoimuy2tlc3tcntahnw2j7s7jjaznawc23zgdgcisma","size":5336}
 {"link":"bagbaieracmkgwrw6rowsk5jse5eihyhszyrq5w23aqosajyckn2tfbotdcqq","size":3297}`
   )
+})
+
+test('asCarLink', (t) => {
+  t.is(asCarLink(Link.parse('bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea')), undefined)
+  const carLink = Link.parse('bagbaieraxkuzouwfuphnqlbbpobywmypb26stej5vbwkelrv7chdqoxfuuea')
+  t.deepEqual(asCarLink(carLink), carLink)
+})
+
+test('parseCarLink', (t) => {
+  /** @type {string | undefined} */
+  let message
+  const error = (/** @type {string} */ msg) => { message = msg }
+
+  const carLink = Link.parse('bagbaieraxkuzouwfuphnqlbbpobywmypb26stej5vbwkelrv7chdqoxfuuea')
+  t.deepEqual(parseCarLink(carLink.toString(), { error }), carLink)
+
+  t.is(parseCarLink('nope', { error }), undefined)
+  t.is(message, 'Error: nope is not a CID')
+
+  t.is(parseCarLink('bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea', { error }), undefined)
+  t.is(message, 'Error: bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea is not a CAR CID')
 })

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -113,16 +113,8 @@ test('asCarLink', (t) => {
 })
 
 test('parseCarLink', (t) => {
-  /** @type {string | undefined} */
-  let message
-  const error = (/** @type {string} */ msg) => { message = msg }
-
   const carLink = Link.parse('bagbaieraxkuzouwfuphnqlbbpobywmypb26stej5vbwkelrv7chdqoxfuuea')
-  t.deepEqual(parseCarLink(carLink.toString(), { error }), carLink)
-
-  t.is(parseCarLink('nope', { error }), undefined)
-  t.is(message, 'Error: nope is not a CID')
-
-  t.is(parseCarLink('bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea', { error }), undefined)
-  t.is(message, 'Error: bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea is not a CAR CID')
+  t.deepEqual(parseCarLink(carLink.toString()), carLink)
+  t.is(parseCarLink('nope'), undefined)
+  t.is(parseCarLink('bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea'), undefined)
 })


### PR DESCRIPTION
adds impl, tests, and docs for the `can store rm` and `can upload rm` commands.

```shell
# remove root cid from upload list
$ w3 can upload rm <root-cid>

# remove car from store
$ w3 can store rm <car-cid>
```


License: MIT