### PR TITLE
feat: import space from base64 string

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -121,7 +121,8 @@ cli
   .action(registerSpace)
 
 cli
-  .command('space add <proof>')
+  .command('space add [proof]')
+  .option('--base64', 'provide proof as base64 encoded string')
   .describe(
     'Add a space to the agent. The proof is a CAR encoded delegation to _this_ agent.'
   )

--- a/lib.js
+++ b/lib.js
@@ -126,19 +126,11 @@ export function getClient() {
 }
 
 /**
- * @param {string} path Path to the proof file.
+ * @param {CarReader} reader
  */
-export async function readProof(path) {
-  try {
-    await fs.promises.access(path, fs.constants.R_OK)
-  } catch (/** @type {any} */ err) {
-    console.error(`Error: failed to read proof: ${err.message}`)
-    process.exit(1)
-  }
-
+export async function proofFromCar(reader) {
   const blocks = []
   try {
-    const reader = await CarReader.fromIterable(fs.createReadStream(path))
     for await (const block of reader.blocks()) {
       blocks.push(block)
     }
@@ -152,6 +144,25 @@ export async function readProof(path) {
     return importDAG(blocks)
   } catch (/** @type {any} */ err) {
     console.error(`Error: failed to import proof: ${err.message}`)
+    process.exit(1)
+  }
+}
+
+/** @param {string} data Base64 encoded CAR file */
+export async function proofFromString (data) {
+  const bytes = Buffer.from(data, 'base64')
+  const reader = await CarReader.fromBytes(bytes)
+  return proofFromCar(reader)
+}
+
+/** @param {string} path Path to the proof file. */
+export async function proofFromPath (path) {
+  try {
+    await fs.promises.access(path, fs.constants.R_OK)
+    const reader = await CarReader.fromIterable(fs.createReadStream(path))
+    return proofFromCar(reader)
+  } catch (/** @type {any} */ err) {
+    console.error(`Error: failed to read proof: ${err.message}`)
     process.exit(1)
   }
 }

--- a/lib.js
+++ b/lib.js
@@ -135,10 +135,9 @@ export async function proofFromCar(reader) {
       blocks.push(block)
     }
   } catch (/** @type {any} */ err) {
-    console.error(`Error: failed to parse proof: ${err.message}`)
+    console.error(`Error: failed to iterate proof: ${err.message}`)
     process.exit(1)
   }
-
   try {
     // @ts-expect-error
     return importDAG(blocks)
@@ -150,8 +149,14 @@ export async function proofFromCar(reader) {
 
 /** @param {string} data Base64 encoded CAR file */
 export async function proofFromString (data) {
-  const bytes = Buffer.from(data, 'base64')
-  const reader = await CarReader.fromBytes(bytes)
+  let reader
+  try {
+    const bytes = Buffer.from(data, 'base64')
+    reader = await CarReader.fromBytes(bytes)
+  } catch (/** @type {any} */ err) {
+    console.error(`Error: failed to parse proof: ${err.message}`)
+    process.exit(1)
+  }
   return proofFromCar(reader)
 }
 
@@ -159,12 +164,18 @@ export async function proofFromString (data) {
 export async function proofFromPath (path) {
   try {
     await fs.promises.access(path, fs.constants.R_OK)
-    const reader = await CarReader.fromIterable(fs.createReadStream(path))
-    return proofFromCar(reader)
   } catch (/** @type {any} */ err) {
     console.error(`Error: failed to read proof: ${err.message}`)
     process.exit(1)
   }
+  let reader
+  try {
+    reader = await CarReader.fromIterable(fs.createReadStream(path))
+  } catch (/** @type {any} */ err) {
+    console.error(`Error: failed to parse proof: ${err.message}`)
+    process.exit(1)
+  }
+  return proofFromCar(reader)
 }
 
 /**


### PR DESCRIPTION
tweak w3cli to make it easier to use in CI where you want to provide state via env vars... aka what if this flow could all be done from w3cli https://gist.github.com/alanshaw/e949abfcf6728f590ac9fa083dba5648

tl;dr what if instead of custom code, the server side of this dance looked like
```bash
$ W3_PRINCIPAL=<ure key here>
$ SPACE_PROOF=<base64 proof string>
$ w3cli space add --base64 $SPACE_PROOF
$ w3cli up ./your/files/here
```

by setting `W3_PRINCIPAL` you w3cli in ci will use the key you generated, and the new `w3cli space add --base64 <proof string>` flag lets you import and use a space proof from a string.

---

Serving suggestion:

## on your local machine

1. Create a keypair for the server

    ```sh
    npx ucan-key ed --json
    ```

    Note down `did` and `key` values!

1. Install the w3cli:

    ```sh
    npm i -g @web3-storage/w3cli
    ```

1. Authorize your agent to use spaces owned by your email address:

    ```sh
    w3 authorize you@email.com
    ```

1. Create a space for where the uploads will be registered:

    ```sh
    w3 space create myspacename
    w3 space register
    ```

1. Delegate from your local machine to the server:

    ```sh
    w3 delegation create <did_from_ucan-key_command_above> --can 'store/add' --can 'upload/add' | base64
    ```

## in CI or ephemeral server

1. Set up environment variables `W3_PRINCIPAL` with the output of `key` from step 1 and `SPACE_PROOF_BASE64` with the output of step 5 above.
1. Install w3cli in your CI workflow, import the space from `SPACE_PROOF_BASE64` and upload your files 
    ```sh 
    w3 space add --base64 $SPACE_PROOF_BASE64 
    w3 up <./path to your file> 
    ```

DONE!



License: MIT