### PR TITLE
feat: add npm package provenance

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,7 +4,7 @@ description: 'Setup and test'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         registry-url: 'https://registry.npmjs.org'
         node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,21 @@ name: Release
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: node
           package-name: '@web3-storage/w3cli'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
       - uses: ./.github/actions/test
-      - run: npm publish
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,5 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,5 @@
 name: Test
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
> a verifiable way to link a package back to its source repository and the specific build instructions used to publish it.

- publish to npm with provenance flag
- update checkout and setup-node actions to v4

see: https://github.blog/2023-04-19-introducing-npm-package-provenance/

License: MIT