### PR TITLE
fix: pin @web3-storage/access to 18.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@ucanto/client": "^9.0.0",
         "@ucanto/core": "^9.0.0",
         "@ucanto/transport": "^9.0.0",
-        "@web3-storage/access": "^18.0.5",
+        "@web3-storage/access": "18.0.5",
         "@web3-storage/data-segment": "^5.0.0",
         "@web3-storage/did-mailto": "^2.1.0",
         "@web3-storage/w3up-client": "^11.2.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ucanto/client": "^9.0.0",
     "@ucanto/core": "^9.0.0",
     "@ucanto/transport": "^9.0.0",
-    "@web3-storage/access": "^18.0.5",
+    "@web3-storage/access": "18.0.5",
     "@web3-storage/data-segment": "^5.0.0",
     "@web3-storage/did-mailto": "^2.1.0",
     "@web3-storage/w3up-client": "^11.2.1",


### PR DESCRIPTION
18.0.6 introduced a bug by using `ArrayBuffer` instead of `Uint8Array`, which doesn't serialize to JSON cleanly. Pin it to 18.0.5 to avoid breaking existing clients.