### PR TITLE
fix: update notification includes -g flag for cli

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -37,7 +37,7 @@ import {
 
 const pkg = getPkg()
 
-updateNotifier({ pkg }).notify()
+updateNotifier({ pkg }).notify({ isGlobal: true })
 
 const cli = sade('w3')
 


### PR DESCRIPTION
The update notifier now specifies the global flag in the npm install advice as this is a cli.

```console
   ╭────────────────────────────────────────────────╮
   │                                                │
   │        Update available 7.0.0 → 7.0.3          │
   │   Run npm i -g @web3-storage/w3cli to update   │
   │                                                │
   ╰────────────────────────────────────────────────╯
```


before this change, it would encourage you to do a local install which is probably not what you want

License: MIT