### PR TITLE
fix: make `w3 up --no-wrap` work as advertised.

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -71,11 +71,11 @@ cli
   .command('up <file>')
   .alias('upload', 'put')
   .describe('Store a file(s) to the service and register an upload.')
-  .option('-H, --hidden', 'Include paths that start with ".".')
+  .option('-H, --hidden', 'Include paths that start with ".".', false)
   .option('-c, --car', 'File is a CAR file.', false)
   .option('--wrap', "Wrap single input file in a directory. Has no effect on directory or CAR uploads. Pass --no-wrap to disable.", true)
-  .option('--json', 'Format as newline delimited JSON')
-  .option('--verbose', 'Output more details.')
+  .option('--json', 'Format as newline delimited JSON', false)
+  .option('--verbose', 'Output more details.', false)
   .option(
     '--shard-size',
     'Shard uploads into CAR files of approximately this size in bytes.'

--- a/bin.js
+++ b/bin.js
@@ -71,9 +71,9 @@ cli
   .command('up <file>')
   .alias('upload', 'put')
   .describe('Store a file(s) to the service and register an upload.')
-  .option('--no-wrap', "Don't wrap input files with a directory.", false)
   .option('-H, --hidden', 'Include paths that start with ".".')
   .option('-c, --car', 'File is a CAR file.', false)
+  .option('--wrap', "Wrap single input file in a directory. Has no effect on directory or CAR uploads. Pass --no-wrap to disable.", true)
   .option('--json', 'Format as newline delimited JSON')
   .option('--verbose', 'Output more details.')
   .option(

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -620,6 +620,70 @@ export const testW3Up = {
     assert.match(up.error, /Stored 1 file/)
   }),
 
+  'w3 up --no-wrap': test(async (assert, context) => {
+    const email = 'alice@web.mail'
+    await login(context, { email })
+    await selectPlan(context, { email })
+
+    const create = await w3
+      .args([
+        'space',
+        'create',
+        'home',
+        '--no-recovery',
+        '--no-account',
+        '--customer',
+        email,
+      ])
+      .env(context.env.alice)
+      .join()
+
+    assert.ok(create.status.success())
+
+    const up = await w3
+      .args(['up', 'test/fixtures/pinpie.jpg', '--no-wrap'])
+      .env(context.env.alice)
+      .join()
+
+    assert.match(
+      up.output,
+      /bafkreiajkbmpugz75eg2tmocmp3e33sg5kuyq2amzngslahgn6ltmqxxfa/
+    )
+    assert.match(up.error, /Stored 1 file/)
+  }),
+
+  'only w3 up --wrap false': test(async (assert, context) => {
+    const email = 'alice@web.mail'
+    await login(context, { email })
+    await selectPlan(context, { email })
+
+    const create = await w3
+      .args([
+        'space',
+        'create',
+        'home',
+        '--no-recovery',
+        '--no-account',
+        '--customer',
+        email,
+      ])
+      .env(context.env.alice)
+      .join()
+
+    assert.ok(create.status.success())
+
+    const up = await w3
+      .args(['up', 'test/fixtures/pinpie.jpg', '--no-wrap'])
+      .env(context.env.alice)
+      .join()
+
+    assert.match(
+      up.output,
+      /bafkreiajkbmpugz75eg2tmocmp3e33sg5kuyq2amzngslahgn6ltmqxxfa/
+    )
+    assert.match(up.error, /Stored 1 file/)
+  }),
+
   'w3 up --car': test(async (assert, context) => {
     const email = 'alice@web.mail'
     await login(context, { email })

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -652,7 +652,7 @@ export const testW3Up = {
     assert.match(up.error, /Stored 1 file/)
   }),
 
-  'only w3 up --wrap false': test(async (assert, context) => {
+  'w3 up --wrap false': test(async (assert, context) => {
     const email = 'alice@web.mail'
     await login(context, { email })
     await selectPlan(context, { email })
@@ -673,7 +673,7 @@ export const testW3Up = {
     assert.ok(create.status.success())
 
     const up = await w3
-      .args(['up', 'test/fixtures/pinpie.jpg', '--no-wrap'])
+      .args(['up', 'test/fixtures/pinpie.jpg', '--wrap', 'false'])
       .env(context.env.alice)
       .join()
 


### PR DESCRIPTION
Fix and test handling of `--wrap` option to `w3 up`

| flag         | result      |
|--------------|-------------|
| undefined    | wrap: true  |
| --wrap       | wrap: true  |
| --wrap true  | wrap: true  |
| --wrap=true  | wrap: true  |
| --wrap false | wrap: false |
| --wrap=false | wrap: false |
| --no-wrap    | wrap: false |

Also normalises the behaviour of other boolean flags to `w3 up` so we can set them like `w3 up --hidden=${{input.hidden}}` in scripts, where it would be fiddly to optionally include a flag. see: https://github.com/web3-storage/add-to-web3/pull/89/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R51

License: MIT