### PR TITLE
feat: add `name` to `w3 space info` output

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,13 +345,17 @@ export async function spaceInfo(opts) {
     }
   }
 
+  const space = client.spaces().find((s) => s.did() === spaceDID)
+  const name = space ? space.name : undefined
+
   if (opts.json) {
-    console.log(JSON.stringify(info, null, 4))
+    console.log(JSON.stringify({ ...info, name }, null, 4))
   } else {
     const providers = info.providers?.join(', ') ?? ''
     console.log(`
       DID: ${info.did}
-Providers: ${providers || chalk.dim('none')}`)
+Providers: ${providers || chalk.dim('none')}
+     Name: ${name ?? chalk.dim('none')}`)
   }
 }
 

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -19,6 +19,7 @@ import * as ED25519 from '@ucanto/principal/ed25519'
 import { sha256, delegate } from '@ucanto/core'
 import * as Result from '@web3-storage/w3up-client/result'
 import { base64 } from 'multiformats/bases/base64'
+import { info } from 'console'
 
 const w3 = Command.create('./bin.js')
 
@@ -533,6 +534,12 @@ export const testSpace = {
       'space has no providers'
     )
 
+    assert.match(
+      infoWithoutProvider.output,
+      pattern`Name: home`,
+      'space name is set'
+    )
+
     Test.provisionSpace(context, {
       space: spaceDID,
       account: 'did:mailto:web.mail:alice',
@@ -549,6 +556,17 @@ export const testSpace = {
       pattern`DID: ${spaceDID}\nProviders: .*${providerDID}`,
       'added provider shows up in the space info'
     )
+
+    const infoWithProviderJson = await w3
+    .args(['space', 'info', '--json'])
+    .env(context.env.alice)
+    .join()
+
+    assert.deepEqual(JSON.parse(infoWithProviderJson.output), {
+      did: spaceDID,
+      providers: [providerDID],
+      name: 'home'
+    })
   }),
 
   'w3 space provision --coupon': test(async (assert, context) => {


### PR DESCRIPTION
It seemed odd that I have to use `w3 space ls` and scan the list to find the `*` to find the name of the currently selected space.

This fixes it so that `w3 space info` includes the name where possible.

The `space/info` capability doesn't provide the meta.name field of a space but perhaps it should.

License: MIT