### PR TITLE
fix: use remove from client

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,43 +204,12 @@ export async function remove(rootCid, opts) {
     process.exit(1)
   }
   const client = await getClient()
-  let upload
+
   try {
-    upload = await client.capability.upload.remove(root)
+    await client.remove(root, opts)
   } catch (/** @type {any} */ err) {
     console.error(`Remove failed: ${err.message ?? err}`)
     console.error(err)
-    process.exit(1)
-  }
-  if (!opts.shards) {
-    return
-  }
-  if (!upload.root) {
-    return console.log(
-      '⁂ upload not found. could not determine shards to remove.'
-    )
-  }
-  if (!upload.shards || !upload.shards.length) {
-    return console.log('⁂ no shards to remove.')
-  }
-
-  const { shards } = upload
-  console.log(
-    `⁂ removing ${shards.length} shard${shards.length === 1 ? '' : 's'}`
-  )
-
-  /** @param {import('@web3-storage/w3up-client/types').CARLink} shard */
-  function removeShard(shard) {
-    return oraPromise(client.capability.store.remove(shard), {
-      text: `${shard}`,
-      successText: `${shard} removed`,
-      failText: `${shard} failed`,
-    })
-  }
-
-  const results = await Promise.allSettled(shards.map(removeShard))
-
-  if (results.some((res) => res.status === 'rejected')) {
     process.exit(1)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@web3-storage/access": "^18.0.7",
         "@web3-storage/data-segment": "^5.0.0",
         "@web3-storage/did-mailto": "^2.1.0",
-        "@web3-storage/w3up-client": "^11.2.1",
+        "@web3-storage/w3up-client": "^12.2.0",
         "ansi-escapes": "^6.2.0",
         "chalk": "^5.3.0",
         "files-from-path": "^1.0.4",
@@ -1617,9 +1617,9 @@
       }
     },
     "node_modules/@web3-storage/access": {
-      "version": "18.0.7",
-      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-18.0.7.tgz",
-      "integrity": "sha512-tVFOZrfYJgt8z5q6jZ9+HnbFUi70qQQ0QEJf41tGao7dJwHMaxa0YfkvbckPWBJuBZIADKvA0ZUJxbawkga/AQ==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-18.1.1.tgz",
+      "integrity": "sha512-q4hB2eKH0CH+FpN3Sj6fsIPrzqYo7QgG3kKklAt36C+nXHnua2X1TZraCsTcZzCvvV9lYtrRcwuROghi7QQAPA==",
       "dependencies": {
         "@ipld/car": "^5.1.1",
         "@ipld/dag-ucan": "^3.4.0",
@@ -1637,7 +1637,7 @@
         "multiformats": "^12.1.2",
         "one-webcrypto": "git+https://github.com/web3-storage/one-webcrypto.git",
         "p-defer": "^4.0.0",
-        "type-fest": "^3.3.0",
+        "type-fest": "^4.9.0",
         "uint8arrays": "^4.0.6"
       }
     },
@@ -1671,6 +1671,17 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@web3-storage/access/node_modules/type-fest": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.1.tgz",
+      "integrity": "sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@web3-storage/capabilities": {
@@ -1860,6 +1871,7 @@
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-12.3.2.tgz",
       "integrity": "sha512-vtf8Sb9GWfde9+tL+9Yu6bpB2Erzk/w99LTW55V6VPF6IdhmvPqAD83/X6w5G7VfxfEbFZ3ElRCqA8hOasP8aQ==",
+      "dev": true,
       "dependencies": {
         "@ipld/car": "^5.2.2",
         "@ipld/dag-cbor": "^9.0.6",
@@ -1878,9 +1890,9 @@
       }
     },
     "node_modules/@web3-storage/w3up-client": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/w3up-client/-/w3up-client-11.2.1.tgz",
-      "integrity": "sha512-04/OfMKUjPoF+l87VjItYFb1wBaljiV8YJbBMlNm9Zf7gazWPDxjfuSWYUMYb8UAPhxQZnV2uGrqUaNqPlUqUg==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/w3up-client/-/w3up-client-12.2.0.tgz",
+      "integrity": "sha512-pAB9ZF9tK05thGCWScqb8sSe1EXkUrZVLZOrZbVLRPl2RQYXYKmjhQLimcjmwwmfLOlK3kNZj0JJhhlzzU3WPQ==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
         "@ucanto/client": "^9.0.0",
@@ -1888,11 +1900,67 @@
         "@ucanto/interface": "^9.0.0",
         "@ucanto/principal": "^9.0.0",
         "@ucanto/transport": "^9.0.0",
-        "@web3-storage/access": "^18.0.5",
-        "@web3-storage/capabilities": "^12.1.0",
+        "@web3-storage/access": "^18.1.1",
+        "@web3-storage/capabilities": "^13.0.0",
         "@web3-storage/did-mailto": "^2.1.0",
         "@web3-storage/filecoin-client": "^3.2.0",
-        "@web3-storage/upload-client": "^12.3.2"
+        "@web3-storage/upload-client": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@web3-storage/w3up-client/node_modules/@web3-storage/capabilities": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/capabilities/-/capabilities-13.0.0.tgz",
+      "integrity": "sha512-SSviDXFweCu8FhaQ7BjsK1WDPBdwoduJhfD2DFRKkZT/V25vdBkqtW4qVc6tfO5IhTVxRpnn62PmbIbbcHzBRQ==",
+      "dependencies": {
+        "@ucanto/core": "^9.0.1",
+        "@ucanto/interface": "^9.0.0",
+        "@ucanto/principal": "^9.0.0",
+        "@ucanto/transport": "^9.0.0",
+        "@ucanto/validator": "^9.0.1",
+        "@web3-storage/data-segment": "^3.2.0"
+      }
+    },
+    "node_modules/@web3-storage/w3up-client/node_modules/@web3-storage/data-segment": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/data-segment/-/data-segment-3.2.0.tgz",
+      "integrity": "sha512-SM6eNumXzrXiQE2/J59+eEgCRZNYPxKhRoHX2QvV3/scD4qgcf4g+paWBc3UriLEY1rCboygGoPsnqYJNyZyfA==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.5",
+        "multiformats": "^11.0.2",
+        "sync-multihash-sha2": "^1.0.0"
+      }
+    },
+    "node_modules/@web3-storage/w3up-client/node_modules/@web3-storage/data-segment/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@web3-storage/w3up-client/node_modules/@web3-storage/upload-client": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-13.0.0.tgz",
+      "integrity": "sha512-NCasbk7msHiQ+e+7TIYiOJyYcoiUlcK44FIYffDX+k4mb9J0qfA93Cw3FQSHe4D/3nEm5nCYs1rNxl07OIOpoQ==",
+      "dependencies": {
+        "@ipld/car": "^5.2.2",
+        "@ipld/dag-cbor": "^9.0.6",
+        "@ipld/dag-ucan": "^3.4.0",
+        "@ipld/unixfs": "^2.1.1",
+        "@ucanto/client": "^9.0.0",
+        "@ucanto/interface": "^9.0.0",
+        "@ucanto/transport": "^9.0.0",
+        "@web3-storage/capabilities": "^13.0.0",
+        "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.1.1",
+        "ipfs-utils": "^9.0.14",
+        "multiformats": "^12.1.2",
+        "p-retry": "^5.1.2",
+        "parallel-transform-web": "^1.0.1",
+        "varint": "^6.0.0"
       }
     },
     "node_modules/@zxing/text-encoding": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@web3-storage/access": "^18.0.7",
     "@web3-storage/data-segment": "^5.0.0",
     "@web3-storage/did-mailto": "^2.1.0",
-    "@web3-storage/w3up-client": "^11.2.1",
+    "@web3-storage/w3up-client": "^12.2.0",
     "ansi-escapes": "^6.2.0",
     "chalk": "^5.3.0",
     "files-from-path": "^1.0.4",

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -774,68 +774,13 @@ export const testW3Up = {
       ])
       .env(context.env.alice)
       .join()
+      .catch()
 
-    assert.equal(rm.status.code, 0)
-    assert.match(
-      rm.output,
-      /upload not found. could not determine shards to remove/
-    )
-  }),
-
-  'w3 remove --shards': test(async (assert, context) => {
-    await loginAndCreateSpace(context)
-
-    const up = await w3
-      .args(['up', 'test/fixtures/pinpie.jpg'])
-      .env(context.env.alice)
-      .join()
-
-    assert.match(
-      up.output,
-      /bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea/
-    )
-
-    const rm = await w3
-      .args([
-        'rm',
-        'bafybeiajdopsmspomlrpaohtzo5sdnpknbolqjpde6huzrsejqmvijrcea',
-        '--shards',
-      ])
-      .env(context.env.alice)
-      .join()
-
-    assert.equal(rm.status.code, 0)
-
-    assert.match(rm.output, /1 shard/)
+    assert.equal(rm.status.code, 1)
     assert.match(
       rm.error,
-      /bagbaieraxkuzouwfuphnqlbbpobywmypb26stej5vbwkelrv7chdqoxfuuea removed/
+      /Upload not found/
     )
-  }),
-
-  'w3 remove --shards - no shards to remove': test(async (assert, context) => {
-    const space = await loginAndCreateSpace(context)
-
-    const root = parseLink(
-      'bafybeih2k7ughhfwedltjviunmn3esueijz34snyay77zmsml5w24tqamm'
-    )
-
-    // store upload without any shards
-    await context.uploadTable.insert({
-      space,
-      root,
-      shards: [],
-      issuer: Test.alice.did(),
-      invocation: parseLink('bafkqaaa'),
-    })
-
-    const rm = await w3
-      .args(['rm', root.toString(), '--shards'])
-      .env(context.env.alice)
-      .join()
-
-    assert.equal(rm.status.code, 0)
-    assert.match(rm.output, /no shards to remove/)
   }),
 }
 


### PR DESCRIPTION
by simply relying on remove from client, we miss some feedback we were providing to the user on the CLI. We could add a `onShardDelete` to client to make it a bit better.  What do you think @alanshaw ?

Error testing for sharding is also now part of client and I removed tests here as they would also have expectations on output/