### PR TITLE
feat: add reset command

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -25,6 +25,7 @@ import {
   usageReport,
   getPlan,
   createKey,
+  reset,
 } from './index.js'
 import {
   storeAdd,
@@ -304,6 +305,11 @@ cli
   .describe('Generate and print a new ed25519 key pair. Does not change your current signing key.')
   .option('--json', 'output as json')
   .action(createKey)
+
+cli
+  .command('reset')
+  .describe('Remove all proofs/delegations from the store but retain the agent DID.')
+  .action(reset)
 
 // show help text if no command provided
 cli.command('help [cmd]', 'Show help text', { default: true }).action((cmd) => {

--- a/index.js
+++ b/index.js
@@ -10,9 +10,11 @@ import { CarWriter } from '@ipld/car'
 import { filesFromPaths } from 'files-from-path'
 import * as Account from './account.js'
 import { spaceAccess } from '@web3-storage/w3up-client/capability/access'
+import { AgentData } from '@web3-storage/access'
 import * as Space from './space.js'
 import {
   getClient,
+  getStore,
   checkPathsExist,
   filesize,
   filesizeMB,
@@ -649,4 +651,16 @@ export async function createKey({ json }) {
     console.log(`# ${signer.did()}`)
     console.log(key)
   }
+}
+
+export const reset = async () => {
+  const store = getStore()
+  const exportData = await store.load()
+  if (exportData) {
+    let data = AgentData.fromExport(exportData)
+    // do not reset the principal
+    data = await AgentData.create({ principal: data.principal, meta: data.meta })
+    await store.save(data.export())
+  }
+  console.log('⁂ Agent reset.')
 }

--- a/lib.js
+++ b/lib.js
@@ -57,11 +57,16 @@ export function filesizeMB(bytes) {
   return `${(bytes / 1000 / 1000).toFixed(1)}MB`
 }
 
+/** Get a configured w3up store used by the CLI. */
+export function getStore() {
+  return new StoreConf({ profile: process.env.W3_STORE_NAME ?? 'w3cli' })
+}
+
 /**
  * Get a new API client configured from env vars.
  */
 export function getClient() {
-  const store = new StoreConf({ profile: process.env.W3_STORE_NAME ?? 'w3cli' })
+  const store = getStore()
 
   if (process.env.W3_ACCESS_SERVICE_URL || process.env.W3_UPLOAD_SERVICE_URL) {
     console.warn(


### PR DESCRIPTION
Adds a reset command so you can reset you agent and login again to gain access to spaces. Retains agent DID.

I called this `reset` and not `logout` because we can't guarantee the agent retains any delegations that are not associated with the currently logged in account(s).

```console
$ w3 whoami
did:key:z6MkiK3h93N8kE6jmAgTWd33QmuyDcsMnaAeQrGjp9iixT2B

$ w3 space ls
  did:key:z6MkoEBnTj96thGj7H7c1DrdNHF4AiA9VPDRVqTmp4teYd6B 
  did:key:z6MketbAFtbeqDeVHxSzSSDH2PfMTquQ3vzZCcPFweXBGe3R 
  did:key:z6MkgVNAd3rDAtvYwp5NscNteZjqW496dERwkMWiDKcZ13xa 
  did:key:z6MkjCoKJcunQgzihb4tXBYDd9xunhpGNoC14HEypgAe5cNW 
  did:key:z6MkfUw42NQV6Gs8ZLr4sujwRFZGQ789LVuRfkgRxFnTkRBz 
* did:key:z6MkwDuRThQcyWjqNsK54yKAmzfsiH6BTkASyiucThMtHt1T Test

$ w3 reset   
⁂ Agent reset.

$ w3 whoami
did:key:z6MkiK3h93N8kE6jmAgTWd33QmuyDcsMnaAeQrGjp9iixT2B

$ w3 space ls

$ w3 login alan.shaw@protocol.ai
⁂ Agent was authorized by did:mailto:protocol.ai:alan.shaw

$ w3 space ls                   
  did:key:z6MkoEBnTj96thGj7H7c1DrdNHF4AiA9VPDRVqTmp4teYd6B 
  did:key:z6MketbAFtbeqDeVHxSzSSDH2PfMTquQ3vzZCcPFweXBGe3R 
  did:key:z6MkgVNAd3rDAtvYwp5NscNteZjqW496dERwkMWiDKcZ13xa 
* did:key:z6MkwDuRThQcyWjqNsK54yKAmzfsiH6BTkASyiucThMtHt1T Test
  did:key:z6MkmyzUC328sSpm8Mncq9aUZuXLsBtARMXhZnEqfWcq11sw Claimer
  did:key:z6MkjCoKJcunQgzihb4tXBYDd9xunhpGNoC14HEypgAe5cNW 
  did:key:z6MkfUw42NQV6Gs8ZLr4sujwRFZGQ789LVuRfkgRxFnTkRBz 
```