### PR TITLE
feat: introduce `bridge generate-tokens` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ w3 up recipies.txt
   - [`w3 proof ls`](#w3-proof-ls)
 - Key management
   - [`w3 key create`](#w3-key-create)
+- UCAN-HTTP Bridge
+  - [`w3 bridge generate-tokens`](#w3-bridge-generate-tokens)
 - Advanced usage
   - [`w3 can space info`](#w3-can-space-info-did) <sup>coming soon!</sup>
   - [`w3 can space recover`](#w3-can-space-recover-email) <sup>coming soon!</sup>
@@ -183,6 +185,12 @@ List proofs of delegated capabilities. Proofs are delegations with an audience m
 Print a new key pair. Does not change your current signing key
 
 - `--json` Export as dag-json
+
+### `w3 bridge generate-tokens`
+
+Generate tokens that can be used as the `X-Auth-Secret` and `Authorization` headers required to use the UCAN-HTTP bridge.
+
+TODO: link to UCAN-HTTP bridge specification once it lands
 
 ### `w3 can space info <did>`
 

--- a/bin.js
+++ b/bin.js
@@ -8,6 +8,7 @@ import {
   Account,
   Space,
   Coupon,
+  Bridge,
   accessClaim,
   addSpace,
   listSpaces,
@@ -178,6 +179,21 @@ cli
     'Path of file to write the exported delegation data to.'
   )
   .action(Coupon.issue)
+
+  cli
+  .command('bridge generate-tokens <did>')
+  .option('-c, --can', 'One or more abilities to delegate.')
+  .option(
+    '-e, --expiration',
+    'Unix timestamp when the delegation is no longer valid. Zero indicates no expiration.',
+    0
+  )
+  .option(
+    '-o, --output',
+    'Path of file to write the exported delegation data to.'
+  )
+  .action(Bridge.generateTokens)
+
 
 cli
   .command('delegation create <audience-did>')

--- a/bridge.js
+++ b/bridge.js
@@ -1,10 +1,9 @@
-import fs from 'node:fs/promises'
 import * as DID from '@ipld/dag-ucan/did'
 import * as Account from './account.js'
 import * as Space from './space.js'
 import { getClient } from './lib.js'
 import * as ucanto from '@ucanto/core'
-import { base64pad } from 'multiformats/bases/base64'
+import { base64url } from 'multiformats/bases/base64'
 import cryptoRandomString from 'crypto-random-string';
 
 export { Account, Space }
@@ -50,8 +49,8 @@ export const generateTokens = async (
   }
 
   console.log(`
-Authorization header: ${base64pad.encode(new TextEncoder().encode(password))}  
+X-Auth-Secret header: ${base64url.encode(new TextEncoder().encode(password))}  
 
-Proof: ${base64pad.encode(bytes)}
+Authorization header: ${base64url.encode(bytes)}
 `)
 }

--- a/bridge.js
+++ b/bridge.js
@@ -1,0 +1,57 @@
+import fs from 'node:fs/promises'
+import * as DID from '@ipld/dag-ucan/did'
+import * as Account from './account.js'
+import * as Space from './space.js'
+import { getClient } from './lib.js'
+import * as ucanto from '@ucanto/core'
+import { base64pad } from 'multiformats/bases/base64'
+import cryptoRandomString from 'crypto-random-string';
+
+export { Account, Space }
+
+/**
+ * @typedef {object} BridgeGenerateTokensOptions
+ * @property {string} resource
+ * @property {string[]|string} [can]
+ * @property {number} [expiration]
+ *
+ * @param {string} resource
+ * @param {BridgeGenerateTokensOptions} options
+ */
+export const generateTokens = async (
+  resource,
+  { can = ['store/add', 'upload/add'], expiration }
+) => {
+  const client = await getClient()
+
+  const resourceDID = DID.parse(resource)
+  const abilities = can ? [can].flat() : []
+  if (!abilities.length) {
+    console.error('Error: missing capabilities for delegation')
+    process.exit(1)
+  }
+
+  const capabilities = /** @type {ucanto.API.Capabilities} */ (
+    abilities.map((can) => ({ can, with: resourceDID.did() }))
+  )
+
+  const password = cryptoRandomString({ length: 32 })
+
+  const coupon = await client.coupon.issue({
+    capabilities,
+    expiration: expiration === 0 ? Infinity : expiration,
+    password,
+  })
+
+  const { ok: bytes, error } = await coupon.archive()
+  if (!bytes) {
+    console.error(error)
+    return process.exit(1)
+  }
+
+  console.log(`
+Authorization header: ${base64pad.encode(new TextEncoder().encode(password))}  
+
+Proof: ${base64pad.encode(bytes)}
+`)
+}

--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ import * as ucanto from '@ucanto/core'
 import { ed25519 } from '@ucanto/principal'
 import chalk from 'chalk'
 export * as Coupon from './coupon.js'
-export * as Bridge from './bridge.js'
 export { Account, Space }
 import ago from 's-ago'
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ import * as ucanto from '@ucanto/core'
 import { ed25519 } from '@ucanto/principal'
 import chalk from 'chalk'
 export * as Coupon from './coupon.js'
+export * as Bridge from './bridge.js'
 export { Account, Space }
 import ago from 's-ago'
 

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -558,9 +558,9 @@ export const testSpace = {
     )
 
     const infoWithProviderJson = await w3
-    .args(['space', 'info', '--json'])
-    .env(context.env.alice)
-    .join()
+      .args(['space', 'info', '--json'])
+      .env(context.env.alice)
+      .join()
 
     assert.deepEqual(JSON.parse(infoWithProviderJson.output), {
       did: spaceDID,
@@ -1269,6 +1269,15 @@ export const testKey = {
     const res = await w3.args(['key', 'create', '--json']).join()
     const key = ED25519.parse(JSON.parse(res.output).key)
     assert.ok(key.did().startsWith('did:key'))
+  }),
+}
+
+export const testBridge = {
+  'w3 bridge generate-tokens': test(async (assert, context) => {
+    const spaceDID = await loginAndCreateSpace(context)
+    const res = await w3.args(['bridge', 'generate-tokens', spaceDID]).join()
+    assert.match(res.output, /X-Auth-Secret header: u/)
+    assert.match(res.output, /Authorization header: u/)
   }),
 }
 


### PR DESCRIPTION
In service of the UCAN bridge implementation in https://github.com/web3-storage/w3infra/pull/325 this PR introduces a new `bridge generate-tokens` command that will generate values for the `X-Auth-Secret` and `Authorization` headers of the HTTP request users make to the bridge.

